### PR TITLE
only change Submit to Submitting... for one form

### DIFF
--- a/touchforms/formplayer/static/formplayer/script/fullform-ui.js
+++ b/touchforms/formplayer/static/formplayer/script/fullform-ui.js
@@ -159,7 +159,7 @@ function Form(json, adapter) {
   }
 
   this.submitting = function() {
-    $('#submit').val('Submitting...');
+    this.$container.find('#submit').val('Submitting...');
   }
 }
 


### PR DESCRIPTION
UX fix for having multiple forms open on the same page at the same time
(for PACT Care Plan report with inline touchforms).

Should probably change all the ids in the generated HTML to classes in
order to make sure forms are correctly encapsulated at some point but
seeing as everything is done with $container.find("#id") at the moment
it's not a huge issue.

Another interaction between multiple forms on the same page is that the
submit button for one is disabled while the other is submitting.  Not
sure if this is necessary but leaving it as is for now.
