### PR TITLE
Don't log heartbeat error messages multiple times

### DIFF
--- a/touchforms/formplayer/static/formplayer/script/xforgasm.js
+++ b/touchforms/formplayer/static/formplayer/script/xforgasm.js
@@ -138,8 +138,8 @@ function WebFormSession(params) {
                         dataType: "json",
                         error: function (jqXHR, textStatus, errorThrown) {
                             var skip_error_msg = false;
-                            if (params.action == "heartbeat"){
-                                if (that.heartbeat_has_failed){
+                            if (params.action == "heartbeat") {
+                                if (that.heartbeat_has_failed) {
                                     // If the xformAjaxAdapter heartbeat can't find the server,
                                     // we only want to log that error one time.
                                     skip_error_msg = true;


### PR DESCRIPTION
Addresses this ticket: http://manage.dimagi.com/default.asp?125687#717321

When CloudCare is open, the server is polled every 60 seconds. If you lose connection to the server an error message is displayed for each heartbeat. This change makes it so that that error message is only displayed once, instead of having them pile up on top of each other.
