### PR TITLE
Fix caselist filtering bug

### DIFF
--- a/touchforms/backend/touchcare.py
+++ b/touchforms/backend/touchcare.py
@@ -198,7 +198,7 @@ class CCInstances(InstanceInitializationFactory):
             sess = CommCareSession(None) # will not passing a CCPlatform cause problems later?
             for k, v in self.vars.iteritems():
                 if k not in meta_keys and k not in exclude_keys:
-                    sess.setDatum(k, str(v))
+                    sess.setDatum(k, unicode(v))
             return from_bundle(sess.getSessionInstance(*([self.vars.get(k, '') for k in meta_keys] + \
                                                          [to_hashtable(self.vars.get('user_data', {}))])))
     


### PR DESCRIPTION
Addresses this ticket: http://manage.dimagi.com/default.asp?133578

CloudCare case lists weren't filtering properly because of this bug. `CommCareSession.setDatum()` takes strings, but a boolean was being passed, thereby raising/throwing an exception.
