### PR TITLE
handle unicode chars

### DIFF
--- a/touchforms/backend/touchcare.py
+++ b/touchforms/backend/touchcare.py
@@ -198,7 +198,7 @@ class CCInstances(InstanceInitializationFactory):
             sess = CommCareSession(None) # will not passing a CCPlatform cause problems later?
             for k, v in self.vars.iteritems():
                 if k not in meta_keys and k not in exclude_keys:
-                    sess.setDatum(k, unicode(v))
+                    sess.setDatum(k, unicode(v, errors='replace'))
             return from_bundle(sess.getSessionInstance(*([self.vars.get(k, '') for k in meta_keys] + \
                                                          [to_hashtable(self.vars.get('user_data', {}))])))
     


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?134995#758126
@czue @NoahCarnahan 

Encoding by Jyson is messed up, it seems to return ISO-8859-1 encoded strings but can't be sure about that.

For now just replace unicode chars.
