### PR TITLE
Fix bug with consecutive question marks in cloudcare text fields

### DIFF
--- a/touchforms/formplayer/static/formplayer/script/xforgasm.js
+++ b/touchforms/formplayer/static/formplayer/script/xforgasm.js
@@ -134,6 +134,7 @@ function WebFormSession(params) {
                     {type: "POST",
                         url: url,
                         data: JSON.stringify(params),
+                        jsonp: false,
                         success: cb,
                         dataType: "json",
                         error: function (jqXHR, textStatus, errorThrown) {


### PR DESCRIPTION
When the jQuery ajax function receives a string in the data parameter, `??` is interpreted as an alias for the jsonp callback function. This fixes the issue. More info [here](http://stackoverflow.com/a/17533499/1739725).
[Ticket](http://manage.dimagi.com/default.asp?151158)
