### PR TITLE
always use current auth when loading xform session

### DIFF
--- a/touchforms/backend/persistence.py
+++ b/touchforms/backend/persistence.py
@@ -13,13 +13,15 @@ def persist(sess):
     timeout = sess.staleness_window
     cache_set(sess_id, state, timeout)
 
-def restore(sess_id, factory):
+def restore(sess_id, factory, override_state=None):
     try:
         state = cache_get(sess_id)
     except KeyError:
         return None
 
     state['uuid'] = sess_id
+    if override_state:
+        state.update(override_state)
     return factory(**state)
 
 # TODO integrate with real caching framework (django ideally)

--- a/touchforms/backend/xformplayer.py
+++ b/touchforms/backend/xformplayer.py
@@ -56,13 +56,13 @@ class global_state_mgr(object):
             self.session_cache[xfsess.uuid] = xfsess
             self.ctx.setNumSessions(len(self.session_cache))
 
-    def get_session(self, session_id):
+    def get_session(self, session_id, override_state=None):
         with self.lock:
             try:
                 return self.session_cache[session_id]
             except KeyError:
                 # see if session has been persisted
-                sess = persistence.restore(session_id, XFormSession)
+                sess = persistence.restore(session_id, XFormSession, override_state)
                 if sess:
                     self.new_session(sess) # repopulate in-memory cache
                     return sess
@@ -632,8 +632,8 @@ def set_locale(session_id, lang):
         ev = xfsess.set_locale(lang)
         return xfsess.response({}, ev)
 
-def current_question(session_id):
-    with global_state.get_session(session_id) as xfsess:
+def current_question(session_id, override_state=None):
+    with global_state.get_session(session_id, override_state) as xfsess:
         extra = {'lang': xfsess.get_lang()}
         extra.update(init_context(xfsess))
         return xfsess.response(extra, xfsess.cur_event)

--- a/touchforms/backend/xformserver.py
+++ b/touchforms/backend/xformserver.py
@@ -206,7 +206,15 @@ def handle_request(content, server):
             if 'session-id' not in content:
                 return {'error': 'session id required'}
 
-            return xformplayer.current_question(content['session-id'])
+            override_state = None
+            # override api_auth with the current auth to avoid issues with expired django sessions
+            # when editing saved forms
+            hq_auth = content.get('hq_auth')
+            if hq_auth:
+                override_state = {
+                    'api_auth': hq_auth,
+                }
+            return xformplayer.current_question(content['session-id'], override_state=override_state)
 
         elif action == 'heartbeat':
             if 'session-id' not in content:


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?153046

Fixes a bug that would give an auth failure message when trying to open an old XForm session for which the django session has expired.