### PR TITLE
Updated travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ branches:
       - master
 install:
   - "pip install test_requirements"
-script: "jasmine-ci --browser phantomjs"
+script: "./run_tests.sh"

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,1 @@
+cd touchforms && jasmine-ci --browser phantomjs && ./manage.py test formplayer


### PR DESCRIPTION
@millerdev was a bit unclear to me what the best practice is here, but got the convention of `run_tests.sh` from the travis site: http://docs.travis-ci.com/user/build-configuration/#script. the reason i only specify `formplayer` tests is so that the django contrib tests do not run