### PR TITLE
Revert removal of preloader support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,16 +24,19 @@ Update your settings.py::
     Add XFORMS_PLAYER_URL = "http://127.0.0.1:4444"
 
 Syncdb::
+
     python manage.py syncdb
 
 Set localsettings.py for this backend::
     add URL_ROOT = "http://your.commcarehq/a/{{DOMAIN}}"
 
 Run the backend::
+
     cd backend
     jython xformserver.py 4444
 
 Run the django frontend::
+
     python manage.py runserver
     
 Play forms!
@@ -56,7 +59,7 @@ Load ledger data     `touchforms.localsettings.URL_ROOT`       Session (cloudcar
 Offline Cloudcare
 =================
 
-To build:
+To build::
 
     cd offline/
     python build.py url-root
@@ -68,21 +71,19 @@ the packaged result will be in dist/standalone (one jar) or dist/split (many jar
 
 Setting up Grunt
 ==================
-Touchforms uses Grunt to run various tasks like compiling HTML templates for the `fullform-ui.js` to use.  First install grunt globally:
+Touchforms uses Grunt to run various tasks like compiling HTML templates for the `fullform-ui.js` to use.  First install grunt globally ::
 
-```
-npm -g install grunt
-```
+    npm -g install grunt
+    npm -g install grunt-cli
 
-Then install all dependencies via the package.json:
+Then install all dependencies via the package.json ::
 
-```
-npm install
-```
+    npm install
 
-Now if you run the grunt `watch` command, grunt will make sure to update compiled versions. For example, editting anything in the `fullform-ui` directory will automatically compile a new `fullform-ui.templates.js`.
+Finally, compile the js files with ::
 
-```
-grunt watch
+    grunt build
 
-```
+Now if you run the grunt `watch` command, grunt will make sure to update compiled versions. For example, editting anything in the `fullform-ui` directory will automatically compile a new `fullform-ui.templates.js`. ::
+
+    grunt watch

--- a/touchforms/backend/xformplayer.py
+++ b/touchforms/backend/xformplayer.py
@@ -122,7 +122,13 @@ def load_form(xform, instance=None, extensions=None, session_data=None, api_auth
     if instance != None:
         XFormParser(None).loadXmlInstance(form, StringReader(instance))
 
-    customhandlers.attach_handlers(form, extensions, context=session_data.get('function_context', {}))
+    # retrieve preloaders out of session_data (for backwards compatibility)
+    customhandlers.attach_handlers(
+        form,
+        extensions,
+        context=session_data.get('function_context', {}),
+        preload_data=session_data.get('preloaders', {})
+    )
 
     form.initialize(instance == None, CCInstances(session_data, api_auth))
     return form


### PR DESCRIPTION
Addresses http://manage.dimagi.com/default.asp?166907
Primarily reverts 3c95c9a6cfaa31891bca99c7cba2e1e7ca05895c (also fixes readme).
I've tested that forms with preloads work, but I'm not certain how to test that I didn't break the ability to register custom function handlers via context. Look ok to you @czue ?
FYI review buddy @biyeun