### PR TITLE
Use loggers

### DIFF
--- a/touchforms/backend/customhandlers.py
+++ b/touchforms/backend/customhandlers.py
@@ -1,3 +1,4 @@
+import logging
 import jarray
 import java.lang
 
@@ -9,7 +10,8 @@ from org.javarosa.core.model.utils import IPreloadHandler
 from org.javarosa.core.model.condition import IFunctionHandler
 from org.javarosa.core.model.data import StringData
 
-import logging
+logger = logging.getLogger('formplayer.customhandlers')
+
 
 def attach_handlers(form, extensions, context, preload_data=None):
     """
@@ -29,7 +31,7 @@ def attach_handlers(form, extensions, context, preload_data=None):
     # NOTE: PRELOADERS ARE DEPRECATED
     for key, data_dict in preload_data.iteritems():
         handler = StaticPreloadHandler(key, data_dict)
-        logging.debug("Adding preloader for %s data: %s" % (key, data_dict))
+        logger.info("Adding preloader for %s data: %s" % (key, data_dict))
         form.getPreloader().addPreloadHandler(handler)
 
 
@@ -40,7 +42,7 @@ def attach_handlers(form, extensions, context, preload_data=None):
             #if this fails, make sure sys.path is correct, and that no intervening
             #__init__.py's do weird stuff (like reference django packages -- the
             #django context probably won't be set up)
-            logging.error('unable to import xforms extension module [%s]' % ext)
+            logger.error('unable to import xforms extension module [%s]' % ext)
             continue
 
         for obj, name in [(getattr(mod, o), o) for o in dir(mod) if not o.startswith('__')]:
@@ -53,7 +55,7 @@ def attach_handlers(form, extensions, context, preload_data=None):
                 if obj.slug() in context:
                     for item in context[obj.slug()]:
                         handler = obj(**item)
-                        logging.debug('adding handler [%s / %s] from module [%s]' % (name, handler.getName(), ext))
+                        logger.info('adding handler [%s / %s] from module [%s]' % (name, handler.getName(), ext))
                         form.exprEvalContext.addFunctionHandler(handler)
 
 

--- a/touchforms/backend/settings.py
+++ b/touchforms/backend/settings.py
@@ -1,3 +1,5 @@
+import logging.handlers
+import sys
 
 # TODO how to harmonize this with django settings?
 
@@ -17,12 +19,41 @@ HACKS_MODE = True
 # base url for touchcare api queries
 URL_ROOT = "{{HOST}}/a/{{DOMAIN}}"
 
+### LOGGING VARIABLES ###
+FORMPLAYER_LOG_FILE = 'formplayer-dev.log'
+
+formats = {
+    'verbose': '%(levelname)s %(asctime)s %(module)s %(process)d %(thread)d %(message)s',
+}
+### END LOGGING VARIABLES ###
+
 try:
     from localsettings import *
 except ImportError:
     pass
 
+### LOGGING CONFIG ###
+formatter = logging.Formatter(formats['verbose'])
+
+logging.basicConfig(
+    stream=sys.stdout,
+    level=logging.INFO,
+    format=formats['verbose']
+)
+
+logger = logging.getLogger('formplayer')
+
+rotatingHandler = logging.handlers.RotatingFileHandler(
+    FORMPLAYER_LOG_FILE,
+    maxBytes=10 * 1024 * 1024,
+    backupCount=20,
+)
+rotatingHandler.setFormatter(formatter)
+
+logger.addHandler(rotatingHandler)
+logger.setLevel(logging.INFO)
+### END LOGGING CONFIG ###
+
 CASE_API_URL = '%s/cloudcare/api/cases/' % URL_ROOT
 FIXTURE_API_URL = '%s/cloudcare/api/fixtures' % URL_ROOT
 LEDGER_API_URL = '%s/cloudcare/api/ledgers/' % URL_ROOT
-

--- a/touchforms/backend/touchcare.py
+++ b/touchforms/backend/touchcare.py
@@ -25,6 +25,9 @@ from org.kxml2.io import KXmlParser
 
 from util import to_vect, to_jdate, to_hashtable, to_input_stream, query_factory
 
+logger = logging.getLogger('formplayer.touchcare')
+
+
 def query_case_ids(q, criteria=None):
     criteria = copy(criteria) or {} # don't modify the passed in dict
     criteria["ids_only"] = 'true'
@@ -135,7 +138,7 @@ class TouchformsStorageUtility(IStorageUtilityIndexed):
         self._objects[object_id] = object
 
     def read(self, record_id):
-        logging.debug('read record %s' % record_id)
+        logger.debug('read record %s' % record_id)
         try:
             # record_id is an int, object_id is a guid
             object_id = self.ids[record_id]
@@ -144,7 +147,7 @@ class TouchformsStorageUtility(IStorageUtilityIndexed):
         return self.read_object(object_id)
 
     def read_object(self, object_id):
-        logging.debug('read object %s' % object_id)
+        logger.debug('read object %s' % object_id)
         if object_id not in self._objects:
             self.put_object(self.fetch_object(object_id))
         try:
@@ -187,7 +190,7 @@ class CaseDatabase(TouchformsStorageUtility):
         self.ids = dict(enumerate(case_ids))
 
     def getIDsForValue(self, field_name, value):
-        logging.debug('case index lookup %s %s' % (field_name, value))
+        logger.debug('case index lookup %s %s' % (field_name, value))
 
         if (field_name, value) not in self.cached_lookups:
             if field_name == 'case-id':
@@ -227,7 +230,7 @@ class LedgerDatabase(TouchformsStorageUtility):
         self.ids = dict(enumerate(case_ids))
 
     def getIDsForValue(self, field_name, value):
-        logging.debug('ledger lookup %s %s' % (field_name, value))
+        logger.debug('ledger lookup %s %s' % (field_name, value))
         if (field_name, value) not in self.cached_lookups:
             if field_name == 'entity-id':
                 ledgers = [self.read_object(value)]

--- a/touchforms/backend/xformplayer.py
+++ b/touchforms/backend/xformplayer.py
@@ -35,7 +35,8 @@ from util import query_factory
 import persistence
 import settings
 
-DEBUG = False
+logger = logging.getLogger('formplayer.xformplayer')
+
 
 class NoSuchSession(Exception):
     pass
@@ -505,11 +506,6 @@ class XFormSession:
             navinfo = {'event': ev_next}
         elif self.nav_mode == 'fao':
             navinfo = {'tree': self.walk()}
-
-        if DEBUG:
-            print '=== walking ==='
-            print_tree(self.walk())
-            print '==============='
 
         resp.update(navinfo)
         resp.update({'seq_id': self.seq_id})

--- a/touchforms/backend/xformserver.py
+++ b/touchforms/backend/xformserver.py
@@ -17,12 +17,7 @@ init_classpath()
 import com.xhaus.jyson.JysonCodec as json
 from xcp import TouchFormsException, InvalidRequestException
 
-logging.basicConfig(
-    stream=sys.stderr,
-    level=logging.DEBUG,
-    format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s'
-)
-
+logger = logging.getLogger('formplayer.xformserver')
 DEFAULT_PORT = 4444
 DEFAULT_STALE_WINDOW = 3. #hours
 
@@ -50,19 +45,19 @@ class XFormRequestHandler(BaseHTTPRequestHandler):
         if 'content-length' in self.headers.dict:
             length = int(self.headers.dict['content-length'])
         else:
-            logging.warn('content length required')
+            logger.warn('content length required')
             self.send_error(400, 'content length required for post')
             return
 
         if 'content-type' not in self.headers.dict or self.headers.dict['content-type'] != 'text/json':
-            logging.warn('content type missing or non-json')
+            logger.warn('content type missing or non-json')
 
         body = self.rfile.read(length)
         try:
-            logging.debug('received: [%s]' % body)
+            logger.debug('received: [%s]' % body)
             data_in = json.loads(body)
         except:
-            logging.warn('content does not parse')
+            logger.warn('content does not parse')
             self.send_error(400, 'content does not parse as valid json')
             return
 
@@ -91,7 +86,7 @@ class XFormRequestHandler(BaseHTTPRequestHandler):
             )
             return
 
-        logging.debug('returned: [%s]' % reply)
+        logger.debug('returned: [%s]' % reply)
 
         self.send_response(200)
         self.send_header('Content-Type', 'text/json; charset=utf-8')
@@ -115,7 +110,7 @@ class XFormRequestHandler(BaseHTTPRequestHandler):
         if human_readable_message is None:
             human_readable_message = message
         explain = long
-        logging.exception("Status Code: %d, Message %s" % (code, message))
+        logger.exception("Status Code: %d, Message %s" % (code, message))
         content = json.dumps({'status': 'error',
                               'error_type': error_type,
                               'code': code, 
@@ -154,6 +149,7 @@ def handle_request(content, server):
     ensure_required_params(['action'], 'All actions', content)
 
     action = content['action']
+    logger.info('Received action %s' % action)
     nav_mode = content.get('nav', 'prompt')
     try:
         if action != xformplayer.Actions.NEW_FORM and action not in touchcare.SUPPORTED_ACTIONS:
@@ -258,7 +254,7 @@ class Purger(threading.Thread):
             if self.purge_due():
                 self.update()
                 result = xformplayer.purge()
-                logging.info('purging sessions: ' + str(result))
+                logger.info('purging sessions: ' + str(result))
 
             time.sleep(0.1)
 
@@ -300,14 +296,14 @@ def main(port=DEFAULT_PORT, stale_window=DEFAULT_STALE_WINDOW, offline=False):
 
     gw = XFormHTTPGateway(port, stale_window, ext_mod)
     gw.start()
-    logging.info('started server on port %d' % port)
+    logger.info('started server on port %d' % port)
 
     purger = Purger()
     purger.start()
-    logging.info('purging sessions inactive for more than %s hours' % stale_window)
+    logger.info('purging sessions inactive for more than %s hours' % stale_window)
 
     if settings.HACKS_MODE:
-        logging.info('hacks mode is enabled, and you should feel bad about that')
+        logger.info('hacks mode is enabled, and you should feel bad about that')
 
     try:
         while True:
@@ -317,7 +313,7 @@ def main(port=DEFAULT_PORT, stale_window=DEFAULT_STALE_WINDOW, offline=False):
 
         #note: the keyboardinterrupt event doesn't seem to be triggered in
         #jython, nor does jython2.5 support the httpserver 'shutdown' method
-        logging.info('interrupted; shutting down...')
+        logger.info('interrupted; shutting down...')
         gw.terminate()
 
 if __name__ == "__main__":


### PR DESCRIPTION
@esoergel fyi @snopoke 
More improvements to loggers. we spit out all of `stdout`, so we get all the junk `println`s in javarosa and these giant received/reply logs. For some reason supervisor isn't filtering out the DEBUG messages. All this results in logs that rapidly use up space so that we go through 10 log files at 52 MB in about 2 hours making it impossible to actually see any trends. Hoping this will be cool to view in splunk and help with figuring out what kind of actions we are seeing. almost positive it's heartbeats. tabbing through a form doesn't trigger a request. sample output:
```
INFO 2015-05-19 15:38:30,723 xformserver 22015 2 started server on port 4444
INFO 2015-05-19 15:38:30,730 xformserver 22015 2 purging sessions inactive for more than 3.0 hours
INFO 2015-05-19 15:38:30,732 xformserver 22015 2 hacks mode is enabled, and you should feel bad about that
INFO 2015-05-19 16:01:04,733 xformserver 22921 8 purging sessions: {'active': 3, 'purged': 0, 'status': 'ok'}
INFO 2015-05-19 16:01:38,740 xformserver 22921 54 Received action heartbeat
INFO 2015-05-19 16:01:44,852 xformserver 22921 55 Received action heartbeat
INFO 2015-05-19 16:01:44,854 xformserver 22921 56 Received action heartbeat
INFO 2015-05-19 16:01:54,036 xformserver 22921 57 Received action new-form
INFO 2015-05-19 16:01:54,961 xformserver 22921 58 Received action heartbeat
```
(also in case you're wondering `dictConfig` doesn't work on 2.5.3)