### PR TITLE
bump log size

### DIFF
--- a/touchforms/backend/settings.py
+++ b/touchforms/backend/settings.py
@@ -45,7 +45,7 @@ logger = logging.getLogger('formplayer')
 
 rotatingHandler = logging.handlers.RotatingFileHandler(
     FORMPLAYER_LOG_FILE,
-    maxBytes=10 * 1024 * 1024,
+    maxBytes=50 * 1024 * 1024,
     backupCount=20,
 )
 rotatingHandler.setFormatter(formatter)


### PR DESCRIPTION
Touchforms eats logs, bumping the size. The removal of heartbeat should help with it too. @snopoke 