### PR TITLE
Optional argument

### DIFF
--- a/touchforms/backend/touchcare.py
+++ b/touchforms/backend/touchcare.py
@@ -256,7 +256,7 @@ class LedgerDatabase(TouchformsStorageUtility):
 
 class CCInstances(InstanceInitializationFactory):
 
-    def __init__(self, sessionvars, api_auth, form_context):
+    def __init__(self, sessionvars, api_auth, form_context=None):
         self.vars = sessionvars
         self.auth = api_auth
         self.fixtures = {}


### PR DESCRIPTION
@czue my pride wouldn't let you fix this. anyways when an xpath query would come in it'd go through filter_cases and instantiate CCInstances. I didn't catch this cause i don't have case filter setup locally (though I should) and didn't think of this. Will write a test that covers that function so we know if it's ever just completely busted.

The breaking line: https://github.com/dimagi/touchforms/blob/optional-arg-form-context/touchforms/backend/touchcare.py#L349

I repro'd by hardcoding an xpath query and seeing the same error pop up