### PR TITLE
Add filter_cases test

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,1 +1,1 @@
-cd touchforms && jasmine-ci --browser phantomjs && jython backend/test_server.py && jython backend/test_xformplayer.py
+cd touchforms && jasmine-ci --browser phantomjs && jython backend/test_server.py && jython backend/test_xformplayer.py && jython backend/test_touchcare.py

--- a/touchforms/backend/test_server.py
+++ b/touchforms/backend/test_server.py
@@ -59,14 +59,28 @@ class XFormServerTest(unittest.TestCase):
         else:
             self.fail()
 
-    def test_no_session_id_touchare(self):
+    def test_touchcare_filter_params(self):
         content = {
             'action': 'touchcare-filter-cases',
+            'filter_expr': 'something',
         }
         try:
             xformserver.handle_request(content, self.server)
-        except Exception:
-            self.fail()
+        except InvalidRequestException, e:
+            self.assertTrue('hq_auth' in e.message)
+        else:
+            self.fail(str(e))
+
+        content = {
+            'action': 'touchcare-filter-cases',
+            'hq_auth': {},
+        }
+        try:
+            xformserver.handle_request(content, self.server)
+        except InvalidRequestException, e:
+            self.assertTrue('filter_expr' in e.message)
+        else:
+            self.fail(str(e))
 
 if __name__ == '__main__':
     unittest.main()

--- a/touchforms/backend/test_touchcare.py
+++ b/touchforms/backend/test_touchcare.py
@@ -78,7 +78,7 @@ class TouchcareTest(unittest.TestCase):
         else:
             self.fail()
 
-    def test_unauthenticated_query(self):
+    def test_unable_to_access_hq(self):
         try:
             touchcare.filter_cases(
                 '',

--- a/touchforms/backend/test_touchcare.py
+++ b/touchforms/backend/test_touchcare.py
@@ -1,0 +1,95 @@
+from __future__ import with_statement
+import unittest
+import os
+
+from setup import init_classpath
+init_classpath()
+
+import touchcare
+from xcp import TouchcareInvalidXPath, TouchFormsUnauthorized
+
+CUR_DIR = os.path.dirname(__file__)
+
+
+class TouchcareTest(unittest.TestCase):
+
+    def setUp(self):
+        with open(os.path.join(CUR_DIR, 'test_files/xforms/xform_simple_cases.xml'), 'r') as f:
+            self.xform = f.read()
+
+        self.session_data = {
+            'session_name': 'Village Healthe > Simple Form',
+            'app_version': '2.0',
+            'device_id': 'cloudcare',
+            'user_id': '51cd680c0bd1c21bb5e63dab99748248',
+            'additional_filters': {'footprint': True},
+            'domain': 'aspace',
+            'host': 'http://localhost:8000',
+            'user_data': {},
+            'case_id_new_RegCase_0': '1c2e7c76f0c84eaea5b44bc7d1d3caf0',
+            'app_id': '6a48b8838d06febeeabb28c8c9516ab6',
+            'username': 'ben'
+        }
+
+        self.case = {
+            'case_id': 'legolas',
+            'properties': {
+                'case_type': 'dragon',
+                'case_name': 'rocky',
+                'date_opened': None,
+                'owner_id': 'ben-123',
+            },
+            'closed': False,
+            'indices': {},
+            'attachments': {},
+        }
+
+    def test_filter_cases(self):
+        filter_expr = "[case_name = 'rocky']"
+
+        resp = touchcare.filter_cases(
+            filter_expr,
+            {},
+            self.session_data,
+            form_context={
+                'cases': [self.case],
+                'all_case_ids': ['legolas', 'gimli'],
+                'case_model': self.case
+            }
+        )
+        self.assertEqual(len(resp['cases']), 1)
+
+    def test_mismatch_xpath(self):
+        filter_expr = "broken"
+
+        try:
+            touchcare.filter_cases(
+                filter_expr,
+                {},
+                self.session_data,
+                form_context={
+                    'cases': [self.case],
+                    'all_case_ids': ['legolas', 'gimli'],
+                    'case_model': self.case
+                }
+            )
+        except TouchcareInvalidXPath, e:
+            self.assertTrue(filter_expr in str(e))
+        else:
+            self.fail()
+
+    def test_unauthenticated_query(self):
+        try:
+            touchcare.filter_cases(
+                '',
+                {},
+                self.session_data,
+            )
+        except TouchFormsUnauthorized, e:
+            self.assertTrue('Unable to connect to HQ' in str(e))
+        else:
+            self.fail()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/touchforms/backend/test_touchcare.py
+++ b/touchforms/backend/test_touchcare.py
@@ -43,6 +43,18 @@ class TouchcareTest(unittest.TestCase):
             'indices': {},
             'attachments': {},
         }
+        self.case_two = {
+            'case_id': 'aragorn',
+            'properties': {
+                'case_type': 'dragon',
+                'case_name': 'smooth_operator',
+                'date_opened': None,
+                'owner_id': 'ben-123',
+            },
+            'closed': False,
+            'indices': {},
+            'attachments': {},
+        }
 
     def test_filter_cases(self):
         filter_expr = "[case_name = 'rocky']"
@@ -52,7 +64,7 @@ class TouchcareTest(unittest.TestCase):
             {},
             self.session_data,
             form_context={
-                'cases': [self.case],
+                'cases': [self.case, self.case_two],
                 'all_case_ids': ['legolas', 'gimli'],
                 'case_model': self.case
             }

--- a/touchforms/backend/touchcare.py
+++ b/touchforms/backend/touchcare.py
@@ -327,9 +327,6 @@ class CCInstances(InstanceInitializationFactory):
         parser.setFeature(KXmlParser.FEATURE_PROCESS_NAMESPACES, True)
         parser.next()
         return TreeElementParser(parser, 0, fixture_id).parse()
-        
-
-SUPPORTED_ACTIONS = ["touchcare-filter-cases"]
 
 
 def filter_cases(filter_expr, api_auth, session_data=None, form_context=None):

--- a/touchforms/backend/touchcare.py
+++ b/touchforms/backend/touchcare.py
@@ -19,6 +19,7 @@ from org.commcare.xml import TreeElementParser
 
 from org.javarosa.xpath.expr import XPathFuncExpr
 from org.javarosa.xpath import XPathParseTool, XPathException
+from org.javarosa.xpath.parser import XPathSyntaxException
 from org.javarosa.core.model.condition import EvaluationContext
 from org.javarosa.core.model.instance import ExternalDataInstance
 
@@ -361,7 +362,7 @@ def filter_cases(filter_expr, api_auth, session_data=None, form_context=None):
             XPathParseTool.parseXPath(modified_xpath).eval(
                 EvaluationContext(None, instances)))
         return {'cases': filter(lambda x: x, case_list.split(","))}
-    except XPathException, e:
+    except (XPathException, XPathSyntaxException), e:
         raise TouchcareInvalidXPath('Error querying cases with xpath %s: %s' % (filter_expr, str(e)))
 
 

--- a/touchforms/backend/touchcare.py
+++ b/touchforms/backend/touchcare.py
@@ -1,5 +1,5 @@
 import urllib
-from urllib2 import HTTPError
+from urllib2 import HTTPError, URLError
 import com.xhaus.jyson.JysonCodec as json
 import logging
 from datetime import datetime
@@ -348,7 +348,7 @@ def filter_cases(filter_expr, api_auth, session_data=None, form_context=None):
 
     try:
         caseInstance.initialize(ccInstances, "casedb")
-    except HTTPError, e:
+    except (HTTPError, URLError), e:
         raise TouchFormsUnauthorized('Unable to connect to HQ: %s' % str(e))
 
     instances = to_hashtable({"casedb": caseInstance})

--- a/touchforms/backend/touchcare.py
+++ b/touchforms/backend/touchcare.py
@@ -1,4 +1,5 @@
 import urllib
+from urllib2 import HTTPError
 import com.xhaus.jyson.JysonCodec as json
 import logging
 from datetime import datetime
@@ -17,13 +18,14 @@ from org.commcare.util import CommCareSession
 from org.commcare.xml import TreeElementParser
 
 from org.javarosa.xpath.expr import XPathFuncExpr
-from org.javarosa.xpath import XPathParseTool
+from org.javarosa.xpath import XPathParseTool, XPathException
 from org.javarosa.core.model.condition import EvaluationContext
 from org.javarosa.core.model.instance import ExternalDataInstance
 
 from org.kxml2.io import KXmlParser
 
 from util import to_vect, to_jdate, to_hashtable, to_input_stream, query_factory
+from xcp import TouchFormsUnauthorized, TouchcareInvalidXPath
 
 logger = logging.getLogger('formplayer.touchcare')
 
@@ -183,8 +185,11 @@ class CaseDatabase(TouchformsStorageUtility):
         return query_case(self.query_func, case_id)
 
     def load_all_objects(self):
-        cases = query_cases(self.query_func,
-                            criteria=self.additional_filters)
+        if self.form_context.get('cases', None):
+            cases = map(lambda c: case_from_json(c), self.form_context.get('cases'))
+        else:
+            cases = query_cases(self.query_func,
+                                criteria=self.additional_filters)
         for c in cases:
             self.put_object(c)
         self.ids = dict(enumerate(self._objects.keys()))
@@ -326,40 +331,42 @@ class CCInstances(InstanceInitializationFactory):
 
 SUPPORTED_ACTIONS = ["touchcare-filter-cases"]
 
-# API stuff
-def handle_request (content, server):
-    action = content['action']
-    if action == "touchcare-filter-cases":
-        return filter_cases(content)
-    else:
-        return {'error': 'unrecognized action'}
 
+def filter_cases(filter_expr, api_auth, session_data=None, form_context=None):
+    session_data = session_data or {}
+    form_context = form_context or {}
+    modified_xpath = "join(',', instance('casedb')/casedb/case%(filters)s/@case_id)" % \
+        {"filters": filter_expr}
 
-def filter_cases(content):
+    # whenever we do a filter case operation we need to load all
+    # the cases, so force this unless manually specified
+    if 'preload_cases' not in session_data:
+        session_data['preload_cases'] = True
+
+    ccInstances = CCInstances(session_data, api_auth, form_context)
+    caseInstance = ExternalDataInstance("jr://instance/casedb", "casedb")
+
     try:
-        modified_xpath = "join(',', instance('casedb')/casedb/case%(filters)s/@case_id)" % \
-                         {"filters": content["filter_expr"]}
-
-        api_auth = content.get('hq_auth')
-        session_data = content.get("session_data", {})
-        # whenever we do a filter case operation we need to load all
-        # the cases, so force this unless manually specified
-        if 'preload_cases' not in session_data:
-            session_data['preload_cases'] = True
-        ccInstances = CCInstances(session_data, api_auth)
-        caseInstance = ExternalDataInstance("jr://instance/casedb", "casedb")
         caseInstance.initialize(ccInstances, "casedb")
-        instances = to_hashtable({"casedb": caseInstance})
+    except HTTPError, e:
+        raise TouchFormsUnauthorized('Unable to connect to HQ: %s' % str(e))
 
-        # load any additional instances needed
-        for extra_instance_config in session_data.get('extra_instances', []):
-            data_instance = ExternalDataInstance(extra_instance_config['src'], extra_instance_config['id'])
-            data_instance.initialize(ccInstances, extra_instance_config['id'])
-            instances[extra_instance_config['id']] = data_instance
+    instances = to_hashtable({"casedb": caseInstance})
 
+    # load any additional instances needed
+    for extra_instance_config in session_data.get('extra_instances', []):
+        data_instance = ExternalDataInstance(extra_instance_config['src'], extra_instance_config['id'])
+        data_instance.initialize(ccInstances, extra_instance_config['id'])
+        instances[extra_instance_config['id']] = data_instance
+
+    try:
         case_list = XPathFuncExpr.toString(
             XPathParseTool.parseXPath(modified_xpath).eval(
                 EvaluationContext(None, instances)))
-        return {'cases': filter(lambda x: x,case_list.split(","))}
-    except Exception, e:
-        return {'status': 'error', 'message': str(e)}
+        return {'cases': filter(lambda x: x, case_list.split(","))}
+    except XPathException, e:
+        raise TouchcareInvalidXPath('Error querying cases with xpath %s: %s' % (filter_expr, str(e)))
+
+
+class Actions:
+    FILTER_CASES = 'touchcare-filter-cases'

--- a/touchforms/backend/xcp.py
+++ b/touchforms/backend/xcp.py
@@ -17,5 +17,23 @@ class EmptyCacheFileException(TouchFormsException):
     pass
 
 
-class InvalidRequestException(TouchFormsException):
+class TouchFormsBadRequest(TouchFormsException):
+    """
+    Raise a subclass of this to return a 400 bad request error code
+    """
+    pass
+
+
+class TouchFormsUnauthorized(TouchFormsException):
+    """
+    Raise a subclass of this to return a 401 unauthorized request error code
+    """
+    pass
+
+
+class InvalidRequestException(TouchFormsBadRequest):
+    pass
+
+
+class TouchcareInvalidXPath(TouchFormsBadRequest):
     pass

--- a/touchforms/backend/xformserver.py
+++ b/touchforms/backend/xformserver.py
@@ -159,9 +159,6 @@ def handle_request(content, server):
     logger.info('Received action %s' % action)
     nav_mode = content.get('nav', 'prompt')
     try:
-        if action != xformplayer.Actions.NEW_FORM and action not in touchcare.SUPPORTED_ACTIONS:
-            ensure_required_params(['session-id'], action, content)
-
         # Formplayer routes
         if action == xformplayer.Actions.NEW_FORM:
             form_fields = {'form-name': 'uid', 'form-content': 'raw', 'form-url': 'url'}
@@ -192,20 +189,24 @@ def handle_request(content, server):
                 })
 
         elif action == xformplayer.Actions.ANSWER:
-            ensure_required_params(['answer'], action, content)
+            ensure_required_params(['session-id', 'answer'], action, content)
             return xformplayer.answer_question(content['session-id'], content['answer'], content.get('ix'))
 
         #sequential (old-style) repeats only
         elif action == xformplayer.Actions.ADD_REPEAT:
+            ensure_required_params(['session-id'], action, content)
             return xformplayer.new_repetition(content['session-id'])
 
         elif action == xformplayer.Actions.NEXT:
+            ensure_required_params(['session-id'], action, content)
             return xformplayer.skip_next(content['session-id'])
 
         elif action == xformplayer.Actions.BACK:
+            ensure_required_params(['session-id'], action, content)
             return xformplayer.go_back(content['session-id'])
 
         elif action == xformplayer.Actions.CURRENT:
+            ensure_required_params(['session-id'], action, content)
             override_state = None
             # override api_auth with the current auth to avoid issues with expired django sessions
             # when editing saved forms
@@ -217,29 +218,34 @@ def handle_request(content, server):
             return xformplayer.current_question(content['session-id'], override_state=override_state)
 
         elif action == xformplayer.Actions.HEARTBEAT:
+            ensure_required_params(['session-id'], action, content)
             return xformplayer.heartbeat(content['session-id'])
 
         elif action == xformplayer.Actions.EDIT_REPEAT:
-            ensure_required_params(['ix'], action, content)
+            ensure_required_params(['session-id', 'ix'], action, content)
             return xformplayer.edit_repeat(content['session-id'], content['ix'])
 
         elif action == xformplayer.Actions.NEW_REPEAT:
+            ensure_required_params(['session-id'], action, content)
             return xformplayer.new_repeat(content['session-id'], content.get('ix'))
         elif action == xformplayer.Actions.DELETE_REPEAT:
-            ensure_required_params(['ix'], action, content)
+            ensure_required_params(['session-id', 'ix'], action, content)
             return xformplayer.delete_repeat(content['session-id'], content['ix'], content.get('form_ix'))
         elif action == xformplayer.Actions.SUBMIT_ALL:
+            ensure_required_params(['session-id'], action, content)
             return xformplayer.submit_form(content['session-id'], content.get('answers', []), content.get('prevalidated', False))
         elif action == xformplayer.Actions.SET_LANG:
-            ensure_required_params(['lang'], action, content)
+            ensure_required_params(['session-id', 'lang'], action, content)
             return xformplayer.set_locale(content['session-id'], content['lang'])
         elif action == xformplayer.Actions.PURGE_STALE:
             ensure_required_params(['window'], action, content)
             return xformplayer.purge(content['window'])
         elif action == xformplayer.Actions.GET_INSTANCE:
+            ensure_required_params(['session-id'], action, content)
             xfsess = xformplayer.global_state.get_session(content['session-id'])
             return {"output": xfsess.output(), "xmlns": xfsess.get_xmlns()}
         elif action == xformplayer.Actions.EVALUATE_XPATH:
+            ensure_required_params(['session-id'], action, content)
             xfsess = xformplayer.global_state.get_session(content['session-id'])
             result = xfsess.evaluate_xpath(content['xpath'])
             return {"output": result['output'], "status": result['status']}


### PR DESCRIPTION
@czue a little bit of a refactor, but should better test `filter_cases` so we'll know if it's broken. I want to modify `cases.js` in HQ so that it will handle 401 and 400 errors by showing the red box with the message. Then if we actually crash on a 500 we send a request to `/jserror/` so we receive an email. Also we'll now be able to see the actual filter expression when it fails on the xpath parsing which'll be super nice. (i'm wrestling with backbone not receiving the correct status code which is why i put the no merge label on)
elf: @snopoke 