### PR TITLE
Do not allow empty submission

### DIFF
--- a/touchforms/backend/test_global_state_manager.py
+++ b/touchforms/backend/test_global_state_manager.py
@@ -1,6 +1,7 @@
 import os
 import unittest
 import xformplayer
+from xcp import FormplayerSubmissionError
 
 CUR_DIR = os.path.dirname(__file__)
 
@@ -103,6 +104,35 @@ class GlobalStateManagerTest(unittest.TestCase):
         })
         self.assertEqual(cached_tree['tree'][0]['answer'], name)
         self.assertEqual(cached.uuid, xform_session.uuid)
+
+    def test_empty_form_submission(self):
+        xform_session = xformplayer.XFormSession(
+            self.xform,
+            instance=None,
+            **self.session_metadata
+        )
+        self.manager.cache_session(xform_session)
+
+        try:
+            xformplayer.submit_form(xform_session.uuid, {'0': None}, False)
+        except FormplayerSubmissionError, e:
+            pass
+        else:
+            self.fail()
+
+    def test_form_submission(self):
+        xform_session = xformplayer.XFormSession(
+            self.xform,
+            instance=None,
+            **self.session_metadata
+        )
+        self.manager.cache_session(xform_session)
+        try:
+            xformplayer.submit_form(xform_session.uuid, {'0': 'Benjamin'}, False)
+        except FormplayerSubmissionError, e:
+            self.fail()
+        else:
+            pass
 
 if __name__ == '__main__':
     unittest.main()

--- a/touchforms/backend/xcp.py
+++ b/touchforms/backend/xcp.py
@@ -37,3 +37,7 @@ class InvalidRequestException(TouchFormsBadRequest):
 
 class TouchcareInvalidXPath(TouchFormsBadRequest):
     pass
+
+
+class FormplayerSubmissionError(TouchFormsBadRequest):
+    pass

--- a/touchforms/backend/xformplayer.py
+++ b/touchforms/backend/xformplayer.py
@@ -35,6 +35,7 @@ from org.javarosa.xpath import XPathException
 from touchcare import CCInstances
 from util import query_factory
 from decorators import require_xform_session
+from xcp import FormplayerSubmissionError
 import persistence
 import settings
 
@@ -676,6 +677,8 @@ def go_back(xform_session):
 # fao mode only
 @require_xform_session
 def submit_form(xform_session, answers, prevalidated):
+    if not filter(lambda a: a is not None, answers.values()):
+        raise FormplayerSubmissionError('A form submission is required to have at least one submission')
     errors = dict(
         filter(lambda resp: resp[1]['status'] != 'success',
             ((_ix, xform_session.answer_question(answer, _ix)) for _ix, answer in answers.iteritems()))


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?167990

@gcapalbo i'm totally convinced this is the expected behavior. if you have no required questions, why shouldn't you be able to submit an empty form? this seems like it should be pushed to the responsibility of the form maker. thought of this after i made the fix so happy discuss/merge

elf: @snopoke