### PR TITLE
Log how long each request takes

### DIFF
--- a/touchforms/backend/xformserver.py
+++ b/touchforms/backend/xformserver.py
@@ -273,7 +273,7 @@ def handle_request(content, server):
         domain = '<unknown>'
         if content.get('session-id', None):
             xfsess = xformplayer.global_state.get_session(content['session-id'])
-            domain = xfsess.orig_params['session_data']['domain']
+            domain = xfsess.orig_params['session_data'].get('domain', '<unknown>')
         elif content.get('session-data', None):
             domain = content['session-data'].get('domain', '<unknown>')
 

--- a/touchforms/backend/xformserver.py
+++ b/touchforms/backend/xformserver.py
@@ -153,6 +153,7 @@ def ensure_required_params(params, action, content):
 
 
 def handle_request(content, server):
+    start = time.time()
     ensure_required_params(['action'], 'All actions', content)
 
     action = content['action']
@@ -267,6 +268,17 @@ def handle_request(content, server):
         return {'error': 'invalid session id'}
     except xformplayer.SequencingException:
         return {'error': 'session is locked by another request'}
+    finally:
+        delta = (time.time() - start) * 1000
+        domain = '<unknown>'
+        if content.get('session-id', None):
+            xfsess = xformplayer.global_state.get_session(content['session-id'])
+            domain = xfsess.orig_params['session_data']['domain']
+        elif content.get('session-data', None):
+            domain = content['session-data'].get('domain', '<unknown>')
+
+        logger.info("Finished processing action %s in %s ms for domain '%s'" % (action, delta, domain))
+
 
 class Purger(threading.Thread):
     def __init__(self, purge_freq=1.):

--- a/touchforms/backend/xformserver.py
+++ b/touchforms/backend/xformserver.py
@@ -271,7 +271,7 @@ def handle_request(content, server):
     finally:
         delta = (time.time() - start) * 1000
         domain = '<unknown>'
-        if content.get('session-id', None):
+        if content.get('session-id', None) and xformplayer.global_state:
             xfsess = xformplayer.global_state.get_session(content['session-id'])
             domain = xfsess.orig_params['session_data'].get('domain', '<unknown>')
         elif content.get('session-data', None):


### PR DESCRIPTION
@czue I talked with Sheel and we think one step we can take is figure out exactly which actions are taking a long time and for what domain and during what time of day. With this added to the log, it should be fairly straightforward to analyze in splunk. I realize this a little bit of an overhead, but it won't be the bottleneck. Right now requests take up to 30 seconds

elf: @dannyroberts 