### PR TITLE
Logger for util

### DIFF
--- a/touchforms/backend/util.py
+++ b/touchforms/backend/util.py
@@ -23,6 +23,9 @@ FormIndex.__repr__ = FormIndex.__json__
 import settings
 import logging
 
+logger = logging.getLogger('formplayer.util')
+
+
 def to_jdate(pdate):
     return Date(pdate.year - 1900, pdate.month - 1, pdate.day)
 
@@ -139,7 +142,7 @@ def query_factory(host='', domain='', auth=None, format="json"):
             opener = urllib2.build_opener(handler)
             req = lambda url: opener.open(url)
 
-        logging.info('making external call: %s' % url)
+        logger.info('making external call: %s' % url)
         return req(url).read()
 
     def json_query(_url):


### PR DESCRIPTION
This is so we can see the external requests in the new `formplayer-clean` logs.
@dannyroberts 