### PR TITLE
Add doc string for storage utility

### DIFF
--- a/touchforms/backend/touchcare.py
+++ b/touchforms/backend/touchcare.py
@@ -105,6 +105,16 @@ class StaticIterator(IStorageIterator):
 
 
 class TouchformsStorageUtility(IStorageUtilityIndexed):
+    """
+    The TouchformsStorageUtility provides an interface for working with the case database. The mobile phone 
+    uses this to populate and reference cases in the SQLite database on the Android phone. Touchforms uses HQ
+    as its "mobile database" so when populating the case universe, it calls HQ to get the case universe for
+    that particular user.
+
+    See:
+    https://github.com/dimagi/javarosa/blob/master/core/src/org/javarosa/core/services/storage/IStorageUtilityIndexed.java
+    for more information on the interface.
+    """
 
     def __init__(self, host, domain, auth, additional_filters=None, preload=False, form_context=None):
         self.cached_lookups = {}

--- a/touchforms/backend/touchcare.py
+++ b/touchforms/backend/touchcare.py
@@ -106,7 +106,7 @@ class StaticIterator(IStorageIterator):
 
 class TouchformsStorageUtility(IStorageUtilityIndexed):
     """
-    The TouchformsStorageUtility provides an interface for working with the case database. The mobile phone 
+    The TouchformsStorageUtility provides an interface for working with the case database. The mobile phone
     uses this to populate and reference cases in the SQLite database on the Android phone. Touchforms uses HQ
     as its "mobile database" so when populating the case universe, it calls HQ to get the case universe for
     that particular user.


### PR DESCRIPTION
This thing has been a bit of a enigma for me, so I'm trying to clear it up for folks in the future. @czue we do need that call to HQ to grab all the case ids because we do not know whether or not the form will reference one of those cases, in say, a count of all the cases.

elf: @dannyroberts 