### PR TITLE
use session specific locks instead of global ones

### DIFF
--- a/touchforms/backend/test_global_state_manager.py
+++ b/touchforms/backend/test_global_state_manager.py
@@ -59,7 +59,7 @@ class GlobalStateManagerTest(unittest.TestCase):
             }
         }
 
-        xformplayer._init(GUIStub())
+        xformplayer._init()
         self.manager = xformplayer.GlobalStateManager.get_globalstate()
 
     def test_basic_sessions(self):

--- a/touchforms/backend/xformplayer.py
+++ b/touchforms/backend/xformplayer.py
@@ -80,16 +80,7 @@ class GlobalStateManager(object):
                     logging.debug("No such session")
                     raise NoSuchSession()
         
-    #todo: we're not calling this currently, but should, or else xform sessions will hang around in memory forever        
-    def destroy_session(self, session_id):
-        # todo: should purge from cache too
-        with self.lock:
-            try:
-                del self.session_cache[session_id]
-            except KeyError:
-                raise NoSuchSession()
-        
-    def save_instance(self, data):                
+    def save_instance(self, data):
         with self.lock:
             self.instance_id_counter += 1
             self.instances[self.instance_id_counter] = data

--- a/touchforms/backend/xformplayer.py
+++ b/touchforms/backend/xformplayer.py
@@ -725,14 +725,10 @@ def prev_event (xfsess):
         at_start, ev = True, xfsess.next_event()
     return at_start, ev
 
-def save_form (xfsess, persist=False):
+def save_form(xfsess):
     xfsess.finalize()
     xml = xfsess.output()
-    if persist:
-        instance_id = global_state.save_instance(xml)
-    else:
-        instance_id = None
-    return (instance_id, xml)
+    return (None, xml)
 
 def form_completion(xfsess):
     return dict(zip(('save-id', 'output'), save_form(xfsess)))

--- a/touchforms/backend/xformplayer.py
+++ b/touchforms/backend/xformplayer.py
@@ -53,15 +53,12 @@ class GlobalStateManager(object):
     instance_id_counter = 0
     session_cache = {}
     
-    def __init__(self, ctx):
-        self.ctx = ctx
+    def __init__(self):
         self.lock = threading.Lock()
-        self.ctx.setNumSessions(0)
 
     def cache_session(self, xfsess):
         with self.lock:
             self.session_cache[xfsess.uuid] = xfsess
-            self.ctx.setNumSessions(len(self.session_cache))
 
     def get_session(self, session_id, override_state=None):
         logging.debug("Getting session id: " + str(session_id))
@@ -117,8 +114,6 @@ class GlobalStateManager(object):
 
         # note that persisted entries use the timeout functionality provided by the caching framework
 
-        self.ctx.setNumSessions(num_sess_active)
-
         return {'purged': num_sess_purged, 'active': num_sess_active}
 
     @classmethod
@@ -128,9 +123,9 @@ class GlobalStateManager(object):
 global_state = None
 
 
-def _init(ctx):
+def _init():
     global global_state
-    global_state = GlobalStateManager(ctx)
+    global_state = GlobalStateManager()
 
 
 def load_form(xform, instance=None, extensions=None, session_data=None, api_auth=None, form_context=None):

--- a/touchforms/backend/xformplayer.py
+++ b/touchforms/backend/xformplayer.py
@@ -90,11 +90,8 @@ class GlobalStateManager(object):
                     num_sess_purged += 1
                 else:
                     num_sess_active += 1
-            #what about saved instances? we don't track when they were saved
-            #for now will just assume instances are not saved
 
         # note that persisted entries use the timeout functionality provided by the caching framework
-
         return {'purged': num_sess_purged, 'active': num_sess_active}
 
     @classmethod
@@ -152,7 +149,7 @@ class SequencingException(Exception):
     pass
 
 
-class XFormSession:
+class XFormSession(object):
     def __init__(self, xform, instance=None, **params):
         self.uuid = params.get('uuid', uuid.uuid4().hex)
         self.lock = threading.Lock()
@@ -605,6 +602,7 @@ def init_context(xfsess):
         'title': xfsess.form_title(),
         'langs': xfsess.get_locales(),
     }
+
 
 def open_form(form_spec, inst_spec=None, **kwargs):
     try:

--- a/touchforms/backend/xformplayer.py
+++ b/touchforms/backend/xformplayer.py
@@ -49,8 +49,6 @@ class NoSuchSession(Exception):
 
 
 class GlobalStateManager(object):
-    instances = {}
-    instance_id_counter = 0
     session_cache = {}
     
     def __init__(self):
@@ -80,12 +78,6 @@ class GlobalStateManager(object):
                     logging.debug("No such session")
                     raise NoSuchSession()
         
-    def save_instance(self, data):
-        with self.lock:
-            self.instance_id_counter += 1
-            self.instances[self.instance_id_counter] = data
-        return self.instance_id_counter
-
     def purge(self):
         num_sess_purged = 0
         num_sess_active = 0

--- a/touchforms/backend/xformplayer.py
+++ b/touchforms/backend/xformplayer.py
@@ -93,12 +93,11 @@ class GlobalStateManager(object):
             now = time.time()
             for sess_id, sess in self.session_cache.items():
                 if now - sess.last_activity > sess.staleness_window:
-                    del self.session_cache[sess_id]
-                    num_sess_purged += 1
-                    # also purge the session lock
-                    if sess_id in self.session_locks:
-                        with self.session_locks[sess_id]:
-                            del self.session_locks[sess_id]
+                    with self.get_lock(sess_id):
+                        del self.session_cache[sess_id]
+                        num_sess_purged += 1
+                        # also purge the session lock
+                        del self.session_locks[sess_id]
                 else:
                     num_sess_active += 1
 

--- a/touchforms/backend/xformplayer.py
+++ b/touchforms/backend/xformplayer.py
@@ -720,19 +720,23 @@ def next_event (xfsess):
         ev.update(form_completion(xfsess))
         return ev
 
+
 def prev_event (xfsess):
     at_start, ev = False, xfsess.back_event()
     if ev['type'] == 'form-start':
         at_start, ev = True, xfsess.next_event()
     return at_start, ev
 
+
 def save_form(xfsess):
     xfsess.finalize()
     xml = xfsess.output()
     return (None, xml)
 
+
 def form_completion(xfsess):
     return dict(zip(('save-id', 'output'), save_form(xfsess)))
+
 
 def get_caption(prompt):
     return {
@@ -743,6 +747,7 @@ def get_caption(prompt):
         # TODO use prompt.getMarkdownText() when commcare jars support it
         'caption_markdown': prompt.getSpecialFormQuestionText("markdown"),
     }
+
 
 def purge():
     resp = global_state.purge()

--- a/touchforms/backend/xformplayer.py
+++ b/touchforms/backend/xformplayer.py
@@ -86,8 +86,6 @@ class GlobalStateManager(object):
             self.instances[self.instance_id_counter] = data
         return self.instance_id_counter
 
-    #todo: add ways to get xml, delete xml, and option not to save xml at all
-
     def purge(self):
         num_sess_purged = 0
         num_sess_active = 0

--- a/touchforms/backend/xformserver.py
+++ b/touchforms/backend/xformserver.py
@@ -332,7 +332,7 @@ def main(port=DEFAULT_PORT, stale_window=DEFAULT_STALE_WINDOW, offline=False):
         settings.PERSIST_SESSIONS = False
     ext_mod = settings.EXTENSION_MODULES
 
-    xformplayer._init(init_gui())
+    xformplayer._init()
 
     gw = XFormHTTPGateway(port, stale_window, ext_mod)
     gw.start()


### PR DESCRIPTION
can be read commit by commit. 

the main change is actually pretty simple/straighforward: https://github.com/dimagi/touchforms/commit/4229b4c66937c98f82a7a6976607bc4d91958cd7. rest is cleanup and removal of code that was either not used at all or only used by offline mode.

@snopoke @benrudolph @TylerSheffels 

it could be good to give this a quick QA pass, though I was pretty careful, ran every line of code that I changed as well as validate the session-specific locks worked as expected. cc @sheelio 