### PR TITLE
More lock cleanup

### DIFF
--- a/touchforms/backend/decorators.py
+++ b/touchforms/backend/decorators.py
@@ -8,7 +8,8 @@ def require_xform_session(fn):
     @wraps(fn)
     def inner(session_id, *args, **kwargs):
         global_state = GlobalStateManager.get_globalstate()
-        with global_state.get_session(session_id) as xform_session:
-            result = fn(xform_session, *args, **kwargs)
-            return result
+        with global_state.get_lock(session_id):
+            with global_state.get_session(session_id) as xform_session:
+                result = fn(xform_session, *args, **kwargs)
+                return result
     return inner

--- a/touchforms/backend/xformplayer.py
+++ b/touchforms/backend/xformplayer.py
@@ -170,7 +170,6 @@ class SequencingException(Exception):
 class XFormSession(object):
     def __init__(self, xform, instance=None, **params):
         self.uuid = params.get('uuid', uuid.uuid4().hex)
-        self.lock = threading.Lock()
         self.nav_mode = params.get('nav_mode', 'prompt')
         self.seq_id = params.get('seq_id', 0)
 

--- a/touchforms/backend/xformplayer.py
+++ b/touchforms/backend/xformplayer.py
@@ -718,9 +718,17 @@ def current_question(xform_session, override_state=None):
 
 
 def heartbeat(session_id):
-    # just touch the session
-    with global_state.get_session(session_id) as xfsess:
-        return {}
+    """
+    The heartbeat will update the session's last seen timestamp and sequence ID.
+    """
+    # todo: cz as of 8/5/2015 I'm pretty sure this isn't necessary. persistence can
+    # just pop this back into the context whenever necessary so no longer super relevant
+    # to keep around in memory while the tab is open.
+    with global_state.get_lock(session_id):
+        # this updates the session stuff and persists it
+        with global_state.get_session(session_id):
+            {}
+
 
 def next_event (xfsess):
     ev = xfsess.next_event()

--- a/touchforms/backend/xformplayer.py
+++ b/touchforms/backend/xformplayer.py
@@ -207,24 +207,24 @@ class XFormSession(object):
         }
         self.update_last_activity()
 
+    def _assert_locked(self):
+        if not global_state.get_lock(self.uuid).locked():
+            # note that this isn't a perfect check that we have the lock
+            # but is hopefully a good enough proxy. this is basically an
+            # assertion.
+            raise Exception('Tried to update XFormSession without the lock!')
+
     def __enter__(self):
-        logger.info('[locking] requesting object lock for session %s' % self.uuid)
-        if self.nav_mode == 'fao':
-            self.lock.acquire()
-        else:
-            if not self.lock.acquire(False):
-                raise SequencingException()
+        self._assert_locked()
         self.seq_id += 1
         self.update_last_activity()
-        logger.info('[locking] got object lock for session %s' % self.uuid)
         return self
 
-    def __exit__(self, *_):
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self._assert_locked()
         if self.persist:
             # TODO should this be done async? we must dump state before releasing the lock, however
             persistence.persist(self)
-        self.lock.release()
-        logger.info('[locking] released object lock for session %s' % self.uuid)
 
     def update_last_activity(self):
         self.last_activity = time.time()
@@ -634,10 +634,13 @@ def open_form(form_spec, inst_spec=None, **kwargs):
 
     xfsess = XFormSession(xform_xml, instance_xml, **kwargs)
     global_state.cache_session(xfsess)
-    with xfsess: # triggers persisting of the fresh session
-        extra = {'session_id': xfsess.uuid}
-        extra.update(init_context(xfsess))
-        return xfsess.response(extra)
+    with global_state.get_lock(xfsess.uuid):
+        with xfsess:
+            # triggers persisting of the fresh session
+            extra = {'session_id': xfsess.uuid}
+            extra.update(init_context(xfsess))
+            response = xfsess.response(extra)
+            return response
 
 
 @require_xform_session

--- a/touchforms/backend/xformplayer.py
+++ b/touchforms/backend/xformplayer.py
@@ -727,7 +727,7 @@ def heartbeat(session_id):
     # just pop this back into the context whenever necessary so no longer super relevant
     # to keep around in memory while the tab is open.
     with global_state.get_lock(session_id):
-        # this updates the session stuff and persists it
+        # this updates the session sequence ID and timestamp and persists it
         with global_state.get_session(session_id):
             {}
 


### PR DESCRIPTION
I think this is the final issue with http://manage.dimagi.com/default.asp?175484

For some reasons the sessions were all sharing a global lock. this just removes that and has them use the session-specific locks.

I'm not sure whether we think we should QA this extensively or not. I filled in some forms etc. and didn't see any issues, and was very careful about searching for usages of both lock types. Open to feedback/pushback on that.

@benrudolph @snopoke 