### PR TITLE
Catch fixture error

### DIFF
--- a/touchforms/backend/touchcare.py
+++ b/touchforms/backend/touchcare.py
@@ -26,7 +26,7 @@ from org.javarosa.core.model.instance import ExternalDataInstance
 from org.kxml2.io import KXmlParser
 
 from util import to_vect, to_jdate, to_hashtable, to_input_stream, query_factory
-from xcp import TouchFormsUnauthorized, TouchcareInvalidXPath, CaseNotFound
+from xcp import TouchFormsUnauthorized, TouchcareInvalidXPath, TouchFormsNotFound, CaseNotFound
 
 logger = logging.getLogger('formplayer.touchcare')
 
@@ -348,7 +348,10 @@ class CCInstances(InstanceInitializationFactory):
                                                         "user": user_id,
                                                         "fixture": fixture_id }
         q = query_factory(self.vars.get('host'), self.vars['domain'], self.auth, format="raw")
-        results = q(query_url)
+        try:
+            results = q(query_url)
+        except (HTTPError, URLError), e:
+            raise TouchFormsNotFound('Unable to fetch fixture at %s: %s' % (query_url, str(e)))
         parser = KXmlParser()
         parser.setInput(to_input_stream(results), "UTF-8")
         parser.setFeature(KXmlParser.FEATURE_PROCESS_NAMESPACES, True)

--- a/touchforms/backend/xcp.py
+++ b/touchforms/backend/xcp.py
@@ -38,6 +38,12 @@ class TouchFormsUnauthorized(TouchFormsException):
     pass
 
 
+class TouchFormsNotFound(TouchFormsException):
+    """
+    Raise a subclass of this to return a 404 not found error code
+    """
+    pass
+
 class InvalidRequestException(TouchFormsBadRequest):
     pass
 

--- a/touchforms/backend/xformserver.py
+++ b/touchforms/backend/xformserver.py
@@ -18,7 +18,8 @@ import com.xhaus.jyson.JysonCodec as json
 from xcp import (
     InvalidRequestException,
     TouchFormsUnauthorized,
-    TouchFormsBadRequest
+    TouchFormsBadRequest,
+    TouchFormsNotFound,
 )
 
 logger = logging.getLogger('formplayer.xformserver')
@@ -73,6 +74,9 @@ class XFormRequestHandler(BaseHTTPRequestHandler):
             return
         except TouchFormsUnauthorized, e:
             self.send_error(401, str(e))
+            return
+        except TouchFormsNotFound, e:
+            self.send_error(404, str(e))
             return
         except (Exception, java.lang.Exception), e:
             msg = ''


### PR DESCRIPTION
This is a much better error message for the user when a fixture is not found. Realized how bad this was when debugging: http://manage.dimagi.com/default.asp?179662#999451

Top one is old message, bottom one is the new message
<img width="1183" alt="screen shot 2015-08-21 at 4 37 19 pm" src="https://cloud.githubusercontent.com/assets/918514/9418560/ee6e7acc-4822-11e5-8623-39f6755d08fd.png">

