### PR TITLE
Better error message

### DIFF
--- a/touchforms/backend/xformplayer.py
+++ b/touchforms/backend/xformplayer.py
@@ -627,9 +627,13 @@ def init_context(xfsess):
 def open_form(form_spec, inst_spec=None, **kwargs):
     try:
         xform_xml = get_loader(form_spec, **kwargs)()
+    except Exception, e:
+        return {'error': 'There was a problem downloading the XForm: %s' % str(e)}
+
+    try:
         instance_xml = get_loader(inst_spec, **kwargs)()
     except Exception, e:
-        return {'error': str(e)}
+        return {'error': 'There was a problem downloading the XForm instance: %s' % str(e)}
 
     xfsess = XFormSession(xform_xml, instance_xml, **kwargs)
     global_state.cache_session(xfsess)


### PR DESCRIPTION
@czue buddy: @biyeun 

This has slightly better error messages. I'm not sure what the best direction for this is. Currently our `download_xform` route gives back an HTML error that looks funny in the error box in cloudcare. https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/app_manager/views.py#L2895. I think it would be nice to return actual errors in a list format based on a query param. Before this change any error would result in the infamous `HTTP Error 404: OK` that doesn't help too much in debugging.
<img width="1215" alt="screen shot 2015-08-24 at 2 46 21 pm" src="https://cloud.githubusercontent.com/assets/918514/9449286/990023b6-4a6f-11e5-8283-dc6be9aaf142.png">
