### PR TITLE
Add auto sync back in

### DIFF
--- a/touchforms/formplayer/templates/formplayer/fullform-ui/templates.html
+++ b/touchforms/formplayer/templates/formplayer/fullform-ui/templates.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 {% load hq_shared_tags %}
 
 <script type="text/html" id="sub-group-fullform-ko-template">
@@ -37,6 +38,20 @@
     {% if request|toggle_enabled:"INSTANCE_VIEWER" %}
         <hr/>
         <div id="instance-xml-home" name="instance-xml-home">
+            <form class="form-horizontal debug-controls">
+                <div class="control-group">
+                    <div class="controls">
+                        <label class="checkbox">
+                            <input id="auto-sync-control" type="checkbox" checked="checked">{% trans "Auto Sync" %}
+                            <span class="help-block">
+                            {% blocktrans %}
+                                When this is checked, the CloudCare Debug tool will auto sync your XML after every question answered. On slow connetions, uncheck this.
+                            {% endblocktrans %}
+                            </span>
+                        </label>
+                    </div>
+                </div>
+            </form>
             <div id="question-viewer-pretty"></div>
             <div id="xml-viewer-pretty"></div>
             <textarea


### PR DESCRIPTION
I think this just got mixed up in a merge. Copied from this PR: https://github.com/dimagi/commcare-hq/pull/7561/files

Basically since the checkbox to autosync never rendered, it was always false and thus the debug tool never loaded

http://manage.dimagi.com/default.asp?182140#1012480

@czue 