### PR TITLE
have caption have normal font-weight

### DIFF
--- a/touchforms/formplayer/static/formplayer/style/webforms.css
+++ b/touchforms/formplayer/static/formplayer/style/webforms.css
@@ -93,11 +93,13 @@ input:invalid {
 }
 
 
-.required .caption:before {
+.required .caption::before {
   content: '*';
   font-weight: bold;
   color: #c0392b;
   margin: 0 3px;
+  right: 0;
+  position: absolute;
 }
 
 .caption {

--- a/touchforms/formplayer/static/formplayer/style/webforms.css
+++ b/touchforms/formplayer/static/formplayer/style/webforms.css
@@ -100,6 +100,10 @@ input:invalid {
   margin: 0 3px;
 }
 
+.caption {
+  font-weight: normal;
+}
+
 .dirty .widget {
     background-color: lightblue;
 }


### PR DESCRIPTION
@orangejenny this overrides our default bolding of label text (not in love with that, but suppose it's nice to have the markdown bold work as expected). the other thing is a bit trickier. since markdown adds a `<p>` block, it messes with the required asterix. the only thing i can think of doing is floating it to the left like in this screenshot:
<img width="1502" alt="screen shot 2015-12-08 at 3 59 58 pm" src="https://cloud.githubusercontent.com/assets/918514/11657617/9deb464e-9dc6-11e5-96e8-1912dea0da32.png">
i don't like it too much though. do you have any ideas?

cc: @czue 