### PR TITLE
Debugger tweaks

### DIFF
--- a/touchforms/formplayer/static/formplayer/script/fullform-ui.js
+++ b/touchforms/formplayer/static/formplayer/script/fullform-ui.js
@@ -366,6 +366,15 @@ Formplayer.ViewModels.CloudCareDebugger = function() {
     self.toggleState = function() {
         self.isMinimized(!self.isMinimized());
     };
+
+    // Called afterRender, ensures that the debugger takes the whole screen
+    self.adjustWidth = function(e) {
+        var $debug = $('#instance-xml-home'),
+            $body = $('body'),
+            margin = 10;
+
+        $debug.width($body.width() - $debug.offset().left - margin);
+    };
 };
 
 Formplayer.ViewModels.EvaluateXPath = function() {

--- a/touchforms/formplayer/static/formplayer/style/webforms.css
+++ b/touchforms/formplayer/static/formplayer/style/webforms.css
@@ -49,6 +49,14 @@
   border-top-right-radius: 5px;
   border-bottom: #ddd solid 4px;
   padding: 6px;
+  cursor: pointer;
+
+  -webkit-transition: background-color 0.5s;
+  transition: background-color 0.5s;
+}
+
+.debugger-tab-title:hover {
+  background-color: #0060E6;
 }
 
 /* Override default nprogress bar color to match CommCareHQ */

--- a/touchforms/formplayer/static/formplayer/style/webforms.css
+++ b/touchforms/formplayer/static/formplayer/style/webforms.css
@@ -40,6 +40,10 @@
   cursor: pointer;
 }
 
+.debugger-code {
+  font-family: monospace;
+}
+
 .debugger-tab-title {
   font-size: 14px;
   line-height: 18px;

--- a/touchforms/formplayer/templates/formplayer/fullform-ui/templates.html
+++ b/touchforms/formplayer/templates/formplayer/fullform-ui/templates.html
@@ -39,7 +39,11 @@
                     </div>
                 </div>
             </form>
-            <div data-bind="template: { name: 'instance-viewer-ko-template', data: cloudCareDebugger }"></div>
+            <div data-bind="template: {
+                name: 'instance-viewer-ko-template',
+                data: cloudCareDebugger,
+                afterRender: cloudCareDebugger.adjustWidth
+            }"></div>
         </div>
     </div>
 </script>

--- a/touchforms/formplayer/templates/formplayer/fullform-ui/templates.html
+++ b/touchforms/formplayer/templates/formplayer/fullform-ui/templates.html
@@ -139,30 +139,29 @@
 <script type="text/html" id="debugger-eval-ko-template">
     <form class="form-horizontal" data-bind="submit: evaluate">
         <div class="form-group">
-            <div class="controls col-sm-12">
-                <textarea
-                    id="evaluate-result"
-                    type="text"
-                    style="display: block;"
-                    readonly
-                    data-bind="
-                        value: result,
-                        css: { 'text-error': !success(), 'form-control': true }
-                "></textarea>
+            <div class="col-sm-12">
+                <div class="input-group">
+                    <input
+                        id="xpath"
+                        class="form-control debugger-code"
+                        name="xpath"
+                        placeholder="/data/[your path here]"
+                        data-bind="value: xpath" />
+                    <span class="input-group-btn">
+                        <button class="btn btn-default" id="evaluate-button">{% trans "Evaluate" %}</button>
+                    </span>
+                </div>
             </div>
         </div>
-        <div data-bind="css: Formplayer.Const.LABEL_OFFSET + ' ' + Formplayer.Const.CONTROL_WIDTH" >
-            <div class="input-group">
-                <input
-                    id="xpath"
-                    class="form-control"
-                    name="xpath"
-                    placeholder="/data/[your path here]"
-                    data-bind="value: xpath" />
-                <span class="input-group-btn">
-                    <button class="btn btn-default" id="evaluate-button">{% trans "Evaluate" %}</button>
-                </span>
-            </div>
+        <div class="col-sm-12">
+            <p
+                id="evaluate-result"
+                type="text"
+                style="display: block;"
+                data-bind="
+                    text: result,
+                    css: { 'text-error': !success() }
+            "></p>
         </div>
     </form>
 </script>

--- a/touchforms/formplayer/templates/formplayer/fullform-ui/templates.html
+++ b/touchforms/formplayer/templates/formplayer/fullform-ui/templates.html
@@ -58,13 +58,14 @@
             }
             ">
             <!-- Tab title -->
-            <div class="debugger-tab-title">
+            <div class="debugger-tab-title" data-bind="
+                click: toggleState
+                ">
                 <i class="debugger-state fa" data-bind="
                     css: {
                         'fa-expand': isMinimized,
                         'fa-compress': !isMinimized()
-                    },
-                    click: toggleState
+                    }
                 "></i>
                 <span>{% trans "CloudCare Debugger" %}</span>
             </div>


### PR DESCRIPTION
This does a couple things based on feedback i got from some of the SA office. @wpride (since zue is intermittent and @proteusvacuum you showed a bit of interest, i tag you as the hq dev!) 

- allows you to click the entire blue bar to expand the debugger (instead of the tiny little arrows)
- resizes the debugger box to the full viewport
- eliminates the weird xpath result box and puts the query box on top (and much larger since the expressions tend to be bigger than the result)

screenshot:
<img width="1552" alt="screen shot 2015-12-17 at 10 14 14 pm" src="https://cloud.githubusercontent.com/assets/918514/11880862/df8ddb9c-a50b-11e5-9801-39ea6d70d468.png">

buddy: @czue