### PR TITLE
fix obscure json parsing issue

### DIFF
--- a/touchforms/formplayer/static/formplayer/script/webformsession.js
+++ b/touchforms/formplayer/static/formplayer/script/webformsession.js
@@ -137,15 +137,14 @@ WebFormSession.prototype.serverRequest = function (requestParams, callback, bloc
 
     this.numPendingRequests++;
     this.onLoading();
-
     $.ajax({
             type: 'POST',
             url: url,
             data: JSON.stringify(requestParams),
-            dataType: "json",
+            dataType: "text"  // we don't use JSON because of a weird bug: http://manage.dimagi.com/default.asp?190983
         })
-        .success(function(resp) { self.handleSuccess(resp, callback); })
-        .fail(self.handleFailure.bind(self));
+        .success(function(resp) { self.handleSuccess(JSON.parse(resp), callback); })
+        .fail(function (resp, textStatus) { self.handleFailure(JSON.parse(resp), textStatus); });
 };
 
 /*

--- a/touchforms/formplayer/views.py
+++ b/touchforms/formplayer/views.py
@@ -228,14 +228,14 @@ def player_proxy(request):
                                  content_type="text/json", auth=DjangoAuth(auth_cookie))
 
         _track_session(request, json.loads(data), json.loads(response))
-        return HttpResponse(response)
+        return HttpResponse(response, content_type='application/json')
     except IOError:
         logging.exception('Unable to connect to touchforms.')
         msg = _(
             'An error occurred while trying to connect to the CloudCare service. '
             'If you have problems filling in the rest of your form please report an issue.'
         )
-        return HttpResponseServerError(json.dumps({'message': msg}))
+        return HttpResponseServerError(json.dumps({'message': msg}), content_type='application/json')
 
 
 def _track_session(request, payload, response):


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?190983

This is pretty weird. JQuery is raising a parsererrror even though the response is valid json. What's even weirder is that returning the same response to a different request doesn't fail - and returning a trivial response to the same request does fail. 

So I think it must be some weird bug/edge case with a super-complicated request triggering a deep bug in jquery.

Others have run into this and one simple workaround is to just bypass jquery's automatic json parser, which seems to work fine http://stackoverflow.com/questions/5095307/jquery-json-response-always-triggers-a-parseerror

Not a very satisfying answer, but seems to fix the issue.

@benrudolph cc @esoergel 