### PR TITLE
Add status filtering hack

### DIFF
--- a/touchforms/backend/touchcare.py
+++ b/touchforms/backend/touchcare.py
@@ -215,10 +215,10 @@ def filter_cases(filter_expr, api_auth, session_data=None, form_context=None,
 
     if uses_sqlite:
         modified_xpath = "join(',', instance('casedb')/casedb/case%(filters)s[@status= 'open']/@case_id)" % \
-                    {"filters": filter_expr}
+                         {"filters": filter_expr}
     else:
         modified_xpath = "join(',', instance('casedb')/casedb/case%(filters)s/@case_id)" % \
-                    {"filters": filter_expr}
+                         {"filters": filter_expr}
     # whenever we do a filter case operation we need to load all
     # the cases, so force this unless manually specified
     if 'preload_cases' not in session_data:

--- a/touchforms/backend/touchcare.py
+++ b/touchforms/backend/touchcare.py
@@ -215,10 +215,10 @@ def filter_cases(filter_expr, api_auth, session_data=None, form_context=None,
 
     if uses_sqlite:
         modified_xpath = "join(',', instance('casedb')/casedb/case%(filters)s[@status= 'open']/@case_id)" % \
-                     {"filters": filter_expr}
+                    {"filters": filter_expr}
     else:
         modified_xpath = "join(',', instance('casedb')/casedb/case%(filters)s/@case_id)" % \
-                     {"filters": filter_expr}
+                    {"filters": filter_expr}
     # whenever we do a filter case operation we need to load all
     # the cases, so force this unless manually specified
     if 'preload_cases' not in session_data:

--- a/touchforms/backend/touchcare.py
+++ b/touchforms/backend/touchcare.py
@@ -213,12 +213,8 @@ def filter_cases(filter_expr, api_auth, session_data=None, form_context=None,
     session_data = session_data or {}
     form_context = form_context or {}
 
-    if uses_sqlite:
-        modified_xpath = "join(',', instance('casedb')/casedb/case%(filters)s[@status= 'open']/@case_id)" % \
-                         {"filters": filter_expr}
-    else:
-        modified_xpath = "join(',', instance('casedb')/casedb/case%(filters)s/@case_id)" % \
-                         {"filters": filter_expr}
+    modified_xpath = "join(',', instance('casedb')/casedb/case%(filters)s[@status= 'open']/@case_id)" % \
+                     {"filters": filter_expr}
     # whenever we do a filter case operation we need to load all
     # the cases, so force this unless manually specified
     if 'preload_cases' not in session_data:

--- a/touchforms/backend/touchcare.py
+++ b/touchforms/backend/touchcare.py
@@ -212,9 +212,13 @@ def filter_cases(filter_expr, api_auth, session_data=None, form_context=None,
                  restore_xml=None, force_sync=True, uses_sqlite=False):
     session_data = session_data or {}
     form_context = form_context or {}
-    modified_xpath = "join(',', instance('casedb')/casedb/case%(filters)s/@case_id)" % \
-                     {"filters": filter_expr}
 
+    if uses_sqlite:
+        modified_xpath = "join(',', instance('casedb')/casedb/case%(filters)s[@status= 'open']/@case_id)" % \
+                     {"filters": filter_expr}
+    else:
+        modified_xpath = "join(',', instance('casedb')/casedb/case%(filters)s/@case_id)" % \
+                     {"filters": filter_expr}
     # whenever we do a filter case operation we need to load all
     # the cases, so force this unless manually specified
     if 'preload_cases' not in session_data:


### PR DESCRIPTION
fix for http://manage.dimagi.com/default.asp?218331#1097316

Previously we removed the 'status' predicate because all filter requests made a couch request that only returned open cases. For the time being we need to hack this in because the alternative is a lot of work and this will soon be done by Formplayer anyways