### PR TITLE
use proper timezoning for java dates

### DIFF
--- a/touchforms/backend/handlers/static.py
+++ b/touchforms/backend/handlers/static.py
@@ -1,6 +1,6 @@
 from customhandlers import TouchformsFunctionHandler
 from java.text import SimpleDateFormat
-
+from java.util import TimeZone
 class StaticFunctionHandler(TouchformsFunctionHandler):
     """
     A function handler that lets you register a static value associated with a function.
@@ -65,5 +65,7 @@ class StaticDateFunctionHandler(StaticFunctionHandler):
                 # remove microseconds if necessary
                 if len(value) == 27:
                     value = '%sZ' % value[:19]
-                parsed_value = SimpleDateFormat("yyyy-MM-dd'T'hh:mm:ss'Z'").parse(value)
+                sdf = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'")
+                sdf.setTimeZone(TimeZone.getTimeZone("UTC"))
+                parsed_value = sdf.parse(value)
             self._value = parsed_value


### PR DESCRIPTION
Adding don't merge because I'm not convinced there isn't a better way to fix this/not clear why this broke yet

see http://manage.dimagi.com/default.asp?212637 

Basically in the XML instance we store the timezone as

`<n0:timeEnd>2016-03-10T15:28:02.589+03</n0:timeEnd>`

Then we load this into the context as:

Time End:  2016-03-10 12:28:02.589000

(IE convert to UTC)

But THEN we're calling this server time (locally for me EAT) in the static handler:

Setting value to parsed:  Thu Mar 10 00:28:02 EAT 2016  from value  2016-03-10T12:28:02Z

And then returning:

Returning ret: Thu Mar 10 00:28:02 EAT 2016 class java.util.Date
