### PR TITLE
More user friendly fixture errors

### DIFF
--- a/touchforms/backend/touchcare.py
+++ b/touchforms/backend/touchcare.py
@@ -179,7 +179,13 @@ class CCInstances(CommCareInstanceInitializer):
         try:
             results = q(query_url)
         except (HTTPError, URLError), e:
-            raise TouchFormsNotFound('Unable to fetch fixture at %s: %s' % (query_url, str(e)))
+            fixture_name = query_url[query_url.rfind('/') + 1:]
+            if "user-group" in fixture_name:
+                raise TouchFormsNotFound('This form requires that the user be in a case sharing group but one could not be found.')
+            elif "commtrack:locations" in fixture_name:
+                raise TouchFormsNotFound('This form requires that the user be assigned to a location but one could not be found.')
+            else:
+                raise TouchFormsNotFound('Unable to fetch fixture %s. Ensure the logged in user has access to this fixture.' % fixture_name)
         parser = KXmlParser()
         parser.setInput(to_input_stream(results), "UTF-8")
         parser.setFeature(KXmlParser.FEATURE_PROCESS_NAMESPACES, True)

--- a/touchforms/backend/touchcare.py
+++ b/touchforms/backend/touchcare.py
@@ -181,11 +181,14 @@ class CCInstances(CommCareInstanceInitializer):
         except (HTTPError, URLError), e:
             fixture_name = query_url[query_url.rfind('/') + 1:]
             if "user-group" in fixture_name:
-                raise TouchFormsNotFound('This form requires that the user be in a case sharing group but one could not be found.')
+                raise TouchFormsNotFound('This form requires that the user be in a case sharing group '
+                                         'but one could not be found.')
             elif "commtrack:locations" in fixture_name:
-                raise TouchFormsNotFound('This form requires that the user be assigned to a location but one could not be found.')
+                raise TouchFormsNotFound('This form requires that the user be assigned to a location '
+                                         'but one could not be found.')
             else:
-                raise TouchFormsNotFound('Unable to fetch fixture %s. Ensure the logged in user has access to this fixture.' % fixture_name)
+                raise TouchFormsNotFound('Unable to fetch fixture %s. '
+                                         'Ensure the logged in user has access to this fixture.' % fixture_name)
         parser = KXmlParser()
         parser.setInput(to_input_stream(results), "UTF-8")
         parser.setFeature(KXmlParser.FEATURE_PROCESS_NAMESPACES, True)


### PR DESCRIPTION
re: http://manage.dimagi.com/default.asp?226894

before
![screen shot 2016-05-13 at 3 59 16 pm](https://cloud.githubusercontent.com/assets/2293064/15260256/b16abd5c-1923-11e6-90de-f8f339564b18.png)

after
![screen shot 2016-05-13 at 3 59 05 pm](https://cloud.githubusercontent.com/assets/2293064/15260257/b4f85eac-1923-11e6-825f-5bba40927b3c.png)