### PR TITLE
split java string too

### DIFF
--- a/touchforms/formplayer/static/formplayer/script/webformsession.js
+++ b/touchforms/formplayer/static/formplayer/script/webformsession.js
@@ -299,7 +299,7 @@ WebFormSession.prototype.newRepeat = function(repeat) {
 
 WebFormSession.prototype.deleteRepeat = function(repetition) {
     var juncture = getIx(repetition.parent);
-    var rep_ix = +(repetition.rel_ix().split(":").slice(-1)[0]);
+    var rep_ix = +(repetition.rel_ix().replace('_',':').split(":").slice(-1)[0]);
     this.serverRequest({
             'action': Formplayer.Const.DELETE_REPEAT,
             'ix': rep_ix,


### PR DESCRIPTION
in this PR we just weren't parsing the Java formIndex string style correctly (uses '_' instead of ':')

Fix for http://manage.dimagi.com/default.asp?227919

cross https://github.com/dimagi/formplayer/pull/42