### PR TITLE
Ensure session id gets set

### DIFF
--- a/touchforms/spec/javascripts/webformsession_spec.js
+++ b/touchforms/spec/javascripts/webformsession_spec.js
@@ -79,7 +79,7 @@ describe('WebForm', function() {
                 params.xform_url,
                 [200,
                 { 'Content-Type': 'application/json' },
-                '{ "status": "success" }']);
+                '{ "status": "success", "session_id": "my-session" }']);
 
             // Setup server constants
             window.XFORM_URL = 'dummy';
@@ -195,6 +195,17 @@ describe('WebForm', function() {
             expect(sess.onerror.calledWith({
                 human_readable_message: Formplayer.Errors.TIMEOUT_ERROR
             })).toBe(true);
+        });
+
+        it('Should ensure session id is set', function() {
+            var sess = new WebFormSession(params),
+                spy = sinon.spy(WebFormSession.prototype, 'renderFormXml');
+            sess.loadForm($('div'), 'en');
+            expect(sess.session_id).toBe(null);
+
+            server.respond();
+            expect(sess.session_id).toBe('my-session');
+            WebFormSession.prototype.renderFormXml.restore();
         });
     });
 });


### PR DESCRIPTION
@czue here's a test for ensuring that the session id gets set. sorry about that, must've missed that somehow. essentially when you call with `.prototype` the `this` object is incorrect. this bug definitely manifests in a weird way. test fails without your fix

cc: @biyeun 