### PR TITLE
add routing directly from browser to formplayer with auth

### DIFF
--- a/touchforms/formplayer/static/formplayer/script/webformsession.js
+++ b/touchforms/formplayer/static/formplayer/script/webformsession.js
@@ -59,6 +59,7 @@ function WebFormSession(params) {
     self.taskQueue = new TaskQueue();
     self.formContext = params.formContext;
     self.domain = params.domain;
+    self.formplayerEnabled = params.formplayerEnabled;
 
     if (params.form_uid) {
         self.formSpec = {type: 'form-name', val: params.form_uid};
@@ -139,14 +140,33 @@ WebFormSession.prototype.serverRequest = function (requestParams, callback, bloc
 
     this.numPendingRequests++;
     this.onLoading();
-    $.ajax({
-            type: 'POST',
-            url: url,
-            data: JSON.stringify(requestParams),
-            dataType: "text"  // we don't use JSON because of a weird bug: http://manage.dimagi.com/default.asp?190983
-        })
-        .success(function(resp) { self.handleSuccess(JSON.parse(resp), callback); })
-        .fail(function (resp, textStatus) { self.handleFailure(JSON.parse(resp), textStatus); });
+
+    if(self.formplayerEnabled){
+        $.ajax({
+                type: 'POST',
+                url: 'http://localhost:8090/' + requestParams.action,
+                data: JSON.stringify(requestParams),
+                contentType: "application/json",
+                dataType: "json",
+                crossDomain: {crossDomain: true},
+                xhrFields: {withCredentials: true},
+            })
+            .success(function (resp) {
+                self.handleSuccess(resp, callback);
+            })
+            .fail(function (resp, textStatus) {
+                self.handleFailure(JSON.parse(resp), textStatus);
+            });
+    } else{
+        $.ajax({
+                type: 'POST',
+                url: url,
+                data: JSON.stringify(requestParams),
+                dataType: "text"  // we don't use JSON because of a weird bug: http://manage.dimagi.com/default.asp?190983
+            })
+            .success(function(resp) { self.handleSuccess(JSON.parse(resp), callback); })
+            .fail(function (resp, textStatus) { self.handleFailure(JSON.parse(resp), textStatus); });
+    }
 };
 
 /*

--- a/touchforms/formplayer/static/formplayer/script/webformsession.js
+++ b/touchforms/formplayer/static/formplayer/script/webformsession.js
@@ -144,7 +144,7 @@ WebFormSession.prototype.serverRequest = function (requestParams, callback, bloc
     if(self.formplayerEnabled){
         $.ajax({
                 type: 'POST',
-                url: 'http://localhost:8090/' + requestParams.action,
+                url: url + "/" + requestParams.action,
                 data: JSON.stringify(requestParams),
                 contentType: "application/json",
                 dataType: "json",

--- a/touchforms/formplayer/views.py
+++ b/touchforms/formplayer/views.py
@@ -222,7 +222,6 @@ def player_proxy(request):
     """
     Proxy to an xform player, to avoid cross-site scripting issues
     """
-
     data = request.body
     auth_cookie = request.COOKIES.get('sessionid')
     try:

--- a/touchforms/formplayer/views.py
+++ b/touchforms/formplayer/views.py
@@ -222,6 +222,7 @@ def player_proxy(request):
     """
     Proxy to an xform player, to avoid cross-site scripting issues
     """
+
     data = request.body
     auth_cookie = request.COOKIES.get('sessionid')
     try:


### PR DESCRIPTION
Pass use_formplayer toggle into webformsession.js, call Formplayer directly with auth cookies 

cross: https://github.com/dimagi/formplayer/pull/49
cross: https://github.com/dimagi/commcare-hq/pull/12186