### PR TITLE
Wp/touchforms sqlite web user

### DIFF
--- a/touchforms/backend/touchcare.py
+++ b/touchforms/backend/touchcare.py
@@ -40,9 +40,7 @@ def get_restore_url(criteria=None):
     return query_url
 
 
-def force_ota_restore(domained_username, auth):
-    username = domained_username.split("@")[0]
-    domain = domained_username.split("@")[1]
+def force_ota_restore(username, domain, auth):
     CCInstances({"username": username, "domain": domain, "host": settings.URL_HOST},
                 auth, force_sync=True, uses_sqlite=True)
     result = {'status': 'OK'}

--- a/touchforms/backend/xformserver.py
+++ b/touchforms/backend/xformserver.py
@@ -259,11 +259,13 @@ def handle_request(content, server):
             result = xfsess.evaluate_xpath(content['xpath'])
             return {"output": result['output'], "status": result['status']}
         elif action == xformplayer.Actions.SYNC_USER_DB:
-            ensure_required_params(['username', 'hq_auth'], action, content)
+            ensure_required_params(['username', 'domain', 'hq_auth'], action, content)
             username = content['username']
+            domain = content['domain']
+            # if a mobile user, we only want the username up to the @{domain}.{host} portion
             if username.endswith('commcarehq.org'):
-                username = content['username'][:content['username'].index('.')]
-            result = touchcare.force_ota_restore(username, auth=content['hq_auth'])
+                username = content['username'][:content['username'].index('@')]
+            result = touchcare.force_ota_restore(username, domain, auth=content['hq_auth'])
             return result
         # Touchcare routes
         elif action == touchcare.Actions.FILTER_CASES:

--- a/touchforms/backend/xformserver.py
+++ b/touchforms/backend/xformserver.py
@@ -260,8 +260,10 @@ def handle_request(content, server):
             return {"output": result['output'], "status": result['status']}
         elif action == xformplayer.Actions.SYNC_USER_DB:
             ensure_required_params(['username', 'hq_auth'], action, content)
-            trimmed_username = content['username'][:content['username'].index('.')]
-            result = touchcare.force_ota_restore(trimmed_username, auth=content['hq_auth'])
+            username = content['username']
+            if username.endswith('commcarehq.org'):
+                username = content['username'][:content['username'].index('.')]
+            result = touchcare.force_ota_restore(username, auth=content['hq_auth'])
             return result
         # Touchcare routes
         elif action == touchcare.Actions.FILTER_CASES:

--- a/touchforms/formplayer/api.py
+++ b/touchforms/formplayer/api.py
@@ -318,7 +318,7 @@ def sync_db(username, domain=None, auth=None):
     data = {
         "action":"sync-db",
         "username": username,
-        "domain:": domain
+        "domain": domain
     }
 
     response = post_data(json.dumps(data), auth)

--- a/touchforms/formplayer/api.py
+++ b/touchforms/formplayer/api.py
@@ -314,7 +314,7 @@ def get_response(data, auth=None):
         raise e
 
 
-def sync_db(username, domain=None, auth=None):
+def sync_db(username, domain, auth):
     data = {
         "action":"sync-db",
         "username": username,


### PR DESCRIPTION
We needed to add the domain to the sync-db request so that web users could also sync. Took the opportunity to clean this up a bit for both types.

See http://manage.dimagi.com/default.asp?230606
Branch from https://github.com/dimagi/touchforms/compare/sk/touchforms-sqlite-web-user?expand=1

