### PR TITLE
Don't force sync on each filter cases call

### DIFF
--- a/touchforms/backend/touchcare.py
+++ b/touchforms/backend/touchcare.py
@@ -50,10 +50,12 @@ def force_ota_restore(username, domain, auth):
 class CCInstances(CommCareInstanceInitializer):
     def __init__(self, sessionvars, auth, restore_xml=None,
                  force_sync=False, form_context=None, uses_sqlite=False):
+        print "CCinstances"
         self.vars = sessionvars
         self.auth = auth
         self.uses_sqlite = uses_sqlite
         if self.uses_sqlite:
+            print "Uses SQLite"
             username = sessionvars['username']
             self.username = username + '@' + sessionvars['domain'] if '@' not in username else username
             self.sandbox = SqlSandboxUtils.getStaticStorage(self.username, settings.SQLITE_DBS_DIRECTORY)
@@ -64,6 +66,7 @@ class CCInstances(CommCareInstanceInitializer):
             CommCareInstanceInitializer.__init__(self, self.sandbox)
 
             if force_sync or self.needs_sync():
+                print "Force sync: ", force_sync, ", neeeds sync: ", self.needs_sync()
                 self.perform_ota_restore(restore_xml)
         else:
             self.fixtures = {}
@@ -224,7 +227,7 @@ def perform_restore(auth, session_data=None, restore_xml=None):
 
 
 def filter_cases(filter_expr, api_auth, session_data=None, form_context=None,
-                 restore_xml=None, force_sync=True, uses_sqlite=False):
+                 restore_xml=None, force_sync=False, uses_sqlite=False):
     session_data = session_data or {}
     form_context = form_context or {}
 

--- a/touchforms/backend/touchcare.py
+++ b/touchforms/backend/touchcare.py
@@ -50,12 +50,10 @@ def force_ota_restore(username, domain, auth):
 class CCInstances(CommCareInstanceInitializer):
     def __init__(self, sessionvars, auth, restore_xml=None,
                  force_sync=False, form_context=None, uses_sqlite=False):
-        print "CCinstances"
         self.vars = sessionvars
         self.auth = auth
         self.uses_sqlite = uses_sqlite
         if self.uses_sqlite:
-            print "Uses SQLite"
             username = sessionvars['username']
             self.username = username + '@' + sessionvars['domain'] if '@' not in username else username
             self.sandbox = SqlSandboxUtils.getStaticStorage(self.username, settings.SQLITE_DBS_DIRECTORY)
@@ -66,7 +64,6 @@ class CCInstances(CommCareInstanceInitializer):
             CommCareInstanceInitializer.__init__(self, self.sandbox)
 
             if force_sync or self.needs_sync():
-                print "Force sync: ", force_sync, ", neeeds sync: ", self.needs_sync()
                 self.perform_ota_restore(restore_xml)
         else:
             self.fixtures = {}


### PR DESCRIPTION
@benrudolph @snopoke think I only added this param in here for testing purposes, should probably just be refactored out (can't think of a situation when you'd want to enforce this on a get_cases call)