### PR TITLE
Update localsettings.py.example

### DIFF
--- a/touchforms/backend/localsettings.py.example
+++ b/touchforms/backend/localsettings.py.example
@@ -10,7 +10,6 @@ PERSISTENCE_DIRECTORY = "/path/to/www/data/touchforms"
 
 USES_POSTGRES = True
 POSTGRES_TABLE = "formplayer_session"
-POSTGRES_JDBC_JAR = "{COMMCARE_HOME}/submodules/touchforms-src/touchforms/backend/jrlib/postgresql-9.4-1201.jdbc41.jar"
 
 POSTGRES_DATABASE = {
         'HOST': 'localhost',


### PR DESCRIPTION
The value for `POSTGRES_JDBC_JAR` in settings.py will be fine for a normal installation, and the value of this line in localsettings.py.example makes it look like "{COMMCARE_HOME}" will be replaced programatically, but it won't!

@wspride @benrudolph cc @emord 