### PR TITLE
don't call toString if arg isn't a date

### DIFF
--- a/touchforms/backend/customhandlers.py
+++ b/touchforms/backend/customhandlers.py
@@ -81,7 +81,9 @@ class FormatForDateFunctionHandler(IFunctionHandler):
         return "format-date-for-calendar"
 
     def eval(self, args, ec):
-        return args[0].toString()
+        if isinstance(args[0], java.util.Date):
+            return args[0].toString()
+        return args[0]
 
 
 class TouchformsFunctionHandler(IFunctionHandler):


### PR DESCRIPTION
Possible fix here: http://manage.dimagi.com/default.asp?234276

Not sure what's going on here exactly - in this form all three calls to this function have a date as their first argument, so not clear why we're receiving a string here. Could be some weird casting going on, could be that the date() method is erroring and returning a blank string.

Either way this will be fixed for real when we merge 2.29 jars here https://github.com/dimagi/touchforms/pull/246