### PR TITLE
Better error handling

### DIFF
--- a/touchforms/formplayer/static/formplayer/script/webformsession.js
+++ b/touchforms/formplayer/static/formplayer/script/webformsession.js
@@ -156,7 +156,7 @@ WebFormSession.prototype.serverRequest = function (requestParams, callback, bloc
                 self.handleSuccess(resp, callback);
             })
             .fail(function (resp, textStatus) {
-                self.handleFailure(JSON.parse(resp), textStatus);
+                self.handleFailure(resp, textStatus);
             });
     } else{
         $.ajax({
@@ -216,7 +216,7 @@ WebFormSession.prototype.handleFailure = function(resp, textStatus) {
     this.onerror({
         human_readable_message: errorMessage
     });
-    this.onLoadingComplete(true);
+    this.onLoadingComplete();
 };
 
 /*


### PR DESCRIPTION
@wpride formplayer returns a proper json error (unlike old touchforms) so we don't need to do json.parse

cc: @czue 