### PR TITLE
Restyle to use bootstrap collapsable in debugger

### DIFF
--- a/touchforms/formplayer/static/formplayer/script/fullform-ui.js
+++ b/touchforms/formplayer/static/formplayer/script/fullform-ui.js
@@ -372,6 +372,10 @@ Formplayer.ViewModels.CloudCareDebugger = function() {
             $body = $('body'),
             margin = 10;
 
+        // On a mobile device or preview mode
+        if ($body.width() < 768) {
+            margin = 0;
+        }
         $debug.width($body.width() - $debug.offset().left - margin);
     };
 };

--- a/touchforms/formplayer/static/formplayer/style/webforms.css
+++ b/touchforms/formplayer/static/formplayer/style/webforms.css
@@ -24,18 +24,13 @@
   transition: height 0.5s;
 }
 
-.debugger .debugger-container {
-  height: 365px;
-  padding: 20px;
-  padding-bottom: 0;
-  border-left: 1px solid #ddd;
-  border-right: 1px solid #ddd;
-}
-
 .debugger .debugger-content {
   overflow-y: auto;
   margin-top: 12px;
   height: 300px;
+  height: 335px;
+  padding: 5px;
+  padding-bottom: 0;
 }
 
 .debugger.debugger-minimized {

--- a/touchforms/formplayer/templates/formplayer/fullform-ui/templates.html
+++ b/touchforms/formplayer/templates/formplayer/fullform-ui/templates.html
@@ -67,33 +67,54 @@
             <!-- Debugger content -->
             <div class="debugger-container">
                 <!-- navigation tabs -->
-                <ul class="nav nav-tabs" role="tablist">
-                    <li role="presentation" class="active">
-                        <a href="#debugger-form-data" aria-controls="debugger-form-data" role="tab" data-toggle="tab">
-                            {% trans "Form Data" %}
-                        </a>
-                    </li>
-                    <li role="presentation">
-                        <a
-                            href="#debugger-xml-instance"
-                            aria-controls="debugger-xml-instance"
-                            role="tab"
-                            id="debugger-xml-instance-tab"
-                            data-toggle="tab">
-                            {% trans "Form XML" %}
-                        </a>
-                    </li>
-                    <li role="presentation">
-                        <a href="#debugger-evaluate" aria-controls="debugger-evaluate" role="tab" data-toggle="tab">
-                            {% trans "Evaluate XPath" %}
-                        </a>
-                    </li>
-                    <li role="presentation">
-                        <a href="#debugger-settings" aria-controls="debugger-settings" role="tab" data-toggle="tab">
-                            {% trans "Settings" %}
-                        </a>
-                    </li>
-                </ul>
+
+                <nav class="navbar navbar-default">
+                  <div class="container-fluid">
+
+                    <div class="navbar-header">
+                      <button
+                            type="button"
+                            class="navbar-toggle collapsed"
+                            data-toggle="collapse"
+                            data-target="#debugger-navbar-collapse" aria-expanded="false">
+                        <span class="sr-only">Toggle navigation</span>
+                        <i class="fa fa-bars"></i> Menu
+                      </button>
+                    </div>
+
+                    <!-- Tab links -->
+                    <div class="collapse navbar-collapse" id="debugger-navbar-collapse">
+                      <ul class="nav navbar-nav">
+                        <li role="presentation" class="active">
+                            <a href="#debugger-form-data" aria-controls="debugger-form-data" role="tab" data-toggle="tab">
+                                {% trans "Form Data" %}
+                            </a>
+                        </li>
+                        <li role="presentation">
+                            <a
+                                href="#debugger-xml-instance"
+                                aria-controls="debugger-xml-instance"
+                                role="tab"
+                                id="debugger-xml-instance-tab"
+                                data-toggle="tab">
+                                {% trans "Form XML" %}
+                            </a>
+                        </li>
+                        <li role="presentation">
+                            <a href="#debugger-evaluate" aria-controls="debugger-evaluate" role="tab" data-toggle="tab">
+                                {% trans "Evaluate XPath" %}
+                            </a>
+                        </li>
+                        <li role="presentation">
+                            <a href="#debugger-settings" aria-controls="debugger-settings" role="tab" data-toggle="tab">
+                                {% trans "Settings" %}
+                            </a>
+                        </li>
+                      </ul>
+                    </div><!-- /.navbar-collapse -->
+                  </div><!-- /.container-fluid -->
+                </nav>
+
                 <!-- tab content -->
                 <div class="tab-content debugger-content">
                     <div role="tabpanel" class="tab-pane active" id="debugger-form-data">


### PR DESCRIPTION
@wpride @biyeun this makes the debugger somwhat compatible in preview mode. still slightly janky:

<img width="337" alt="screen shot 2016-08-30 at 12 05 34 pm" src="https://cloud.githubusercontent.com/assets/918514/18097038/4f089b66-6eaa-11e6-83b9-e40e9cd68cf2.png">
<img width="371" alt="screen shot 2016-08-30 at 12 05 25 pm" src="https://cloud.githubusercontent.com/assets/918514/18097039/4f097298-6eaa-11e6-888a-1861fb624cca.png">
<img width="1417" alt="screen shot 2016-08-30 at 12 02 19 pm" src="https://cloud.githubusercontent.com/assets/918514/18097040/4f0ba0fe-6eaa-11e6-9d8b-78bc2ad7a879.png">
