### PR TITLE
Remove logic around presentation group

### DIFF
--- a/touchforms/backend/xformplayer.py
+++ b/touchforms/backend/xformplayer.py
@@ -322,11 +322,9 @@ class XFormSession(object):
             evt = self.__parse_event(form_ix)
             evt['relevant'] = relevant
             if evt['type'] == 'sub-group':
-                presentation_group = (evt['caption'] != None)
-                if presentation_group:
-                    siblings.append(evt)
-                    evt['children'] = []
-                form_ix = self._walk(form_ix, evt['children'] if presentation_group else siblings)
+                siblings.append(evt)
+                evt['children'] = []
+                form_ix = self._walk(form_ix, evt['children'])
             elif evt['type'] == 'repeat-juncture':
                 siblings.append(evt)
                 evt['children'] = []


### PR DESCRIPTION
@wpride @czue we have this weird branching logic around whether or not a group has a label or not. i can't tell why it was ever used, maybe you guys have more insight? it fixes the issue where TF crashes if repeats don't have labels (much more prevalent now that that's the default)

cc: @dannyroberts 