### PR TITLE
Password support

### DIFF
--- a/touchforms/formplayer/static/formplayer/script/entrycontrols_full.js
+++ b/touchforms/formplayer/static/formplayer/script/entrycontrols_full.js
@@ -131,7 +131,7 @@ UnsupportedEntry.prototype.constructor = Entry;
 function FreeTextEntry(question, options) {
     var self = this;
     EntrySingleAnswer.call(self, question, options);
-    var isPassword = question.control() === Formplayer.Const.CONTROL_SECRET;
+    var isPassword = ko.utils.unwrapObservable(question.control) === Formplayer.Const.CONTROL_SECRET;
     if (isPassword) {
         self.templateType = 'password';
     } else {

--- a/touchforms/formplayer/static/formplayer/script/entrycontrols_full.js
+++ b/touchforms/formplayer/static/formplayer/script/entrycontrols_full.js
@@ -131,7 +131,12 @@ UnsupportedEntry.prototype.constructor = Entry;
 function FreeTextEntry(question, options) {
     var self = this;
     EntrySingleAnswer.call(self, question, options);
-    self.templateType = 'text';
+    var isPassword = question.control() === Formplayer.Const.CONTROL_SECRET;
+    if (isPassword) {
+        self.templateType = 'password';
+    } else {
+        self.templateType = 'text';
+    }
     self.domain = question.domain ? question.domain() : 'full';
     self.lengthLimit = options.lengthLimit || 100000;
     self.prose = question.domain_meta ? question.domain_meta().longtext : false;
@@ -149,7 +154,7 @@ function FreeTextEntry(question, options) {
     };
 
     self.helpText = function() {
-        return 'Free response';
+        return isPassword ? 'Password' : 'Free response';
     };
 }
 FreeTextEntry.prototype = Object.create(EntrySingleAnswer.prototype);

--- a/touchforms/formplayer/static/formplayer/script/fullform-ui.js
+++ b/touchforms/formplayer/static/formplayer/script/fullform-ui.js
@@ -485,6 +485,22 @@ Formplayer.Const = {
     SET_LANG: 'set-lang',
     SUBMIT: 'submit-all',
 
+    // Control values. See commcare/javarosa/src/main/java/org/javarosa/core/model/Constants.java
+    CONTROL_UNTYPED: -1,
+    CONTROL_INPUT: 1,
+    CONTROL_SELECT_ONE: 2,
+    CONTROL_SELECT_MULTI: 3,
+    CONTROL_TEXTAREA: 4,
+    CONTROL_SECRET: 5,
+    CONTROL_RANGE: 6,
+    CONTROL_UPLOAD: 7,
+    CONTROL_SUBMIT: 8,
+    CONTROL_TRIGGER: 9,
+    CONTROL_IMAGE_CHOOSE: 10,
+    CONTROL_LABEL: 11,
+    CONTROL_AUDIO_CAPTURE: 12,
+    CONTROL_VIDEO_CAPTURE: 13,
+
 };
 
 Formplayer.Errors = {

--- a/touchforms/formplayer/templates/formplayer/fullform-ui/templates.html
+++ b/touchforms/formplayer/templates/formplayer/fullform-ui/templates.html
@@ -275,6 +275,14 @@
         text: helpText()
     "></span>
 </script>
+
+<script type="text/html" id="password-entry-ko-template">
+    <input type="password" class="form-control" data-bind="
+        value: $data.rawAnswer,
+    "/>
+    <span class="help-block type" data-bind="text: helpText()"></span>
+</script>
+
 <script type="text/html" id="str-entry-ko-template">
     <input type="text" class="form-control" data-bind="
         value: $data.rawAnswer,


### PR DESCRIPTION
@wpride @czue some last bit cloudcare support work
<img width="872" alt="screen shot 2016-09-12 at 10 03 23 am" src="https://cloud.githubusercontent.com/assets/918514/18438799/d3627df2-78d0-11e6-9217-9612baea0118.png">
cc: @gcapalbo 

won't crash if this isn't merged, just will continue to display the free response entry for passwords https://github.com/dimagi/formplayer/pull/128 for it to actually work