### PR TITLE
assign on_delete explicitly

### DIFF
--- a/touchforms/formplayer/migrations/0001_initial.py
+++ b/touchforms/formplayer/migrations/0001_initial.py
@@ -22,7 +22,7 @@ class Migration(migrations.Migration):
                 ('session_name', models.CharField(max_length=100)),
                 ('created_date', models.DateTimeField(default=datetime.datetime.utcnow)),
                 ('last_activity_date', models.DateTimeField(null=True)),
-                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE)),
             ],
             options={
             },

--- a/touchforms/formplayer/models.py
+++ b/touchforms/formplayer/models.py
@@ -32,7 +32,7 @@ class Session(models.Model):
 
 class EntrySession(models.Model):
     session_id = models.CharField(max_length=100, primary_key=True)
-    user = models.ForeignKey(User)
+    user = models.ForeignKey(User, on_delete=models.CASCADE)
     form = models.CharField(max_length=255)  # url of cloudcare form
     app_id = models.CharField(max_length=32, null=True, blank=True)  # HQ app ID, if relevant
     session_name = models.CharField(max_length=100)


### PR DESCRIPTION
Get rid of warnings like

```RemovedInDjango20Warning: on_delete will be a required arg for ForeignKey in Django 2.0. Set it to models.CASCADE on models and in existing migrations if you want to maintain the current default behavior. See https://docs.djangoproject.com/en/1.9/ref/models/fields/#django.db.models.ForeignKey.on_delete```

that appear when running django 1.9.  Although it's not needed until django 2.0, I'd just like to see less warnings now.

@sravfeyn @dannyroberts 