### PR TITLE
decode payload as utf-8

### DIFF
--- a/touchforms/backend/touchcare.py
+++ b/touchforms/backend/touchcare.py
@@ -87,7 +87,7 @@ class CCInstances(CommCareInstanceInitializer):
 
     def get_restore_xml(self):
         payload = self.query_func(self.query_url)
-        return payload
+        return payload.decode('utf-8')
 
     def needs_sync(self):
         try:


### PR DESCRIPTION
Properly decodes the xml payload as utf8:
<img width="1159" alt="screen shot 2016-11-03 at 12 14 09 pm" src="https://cloud.githubusercontent.com/assets/918514/19974554/392c28d8-a1bf-11e6-8f99-38952d60d745.png">
@wpride 
cc: @NoahCarnahan 