### PR TITLE
Don't process XML when it has errors

### DIFF
--- a/touchforms/backend/xformplayer.py
+++ b/touchforms/backend/xformplayer.py
@@ -723,15 +723,15 @@ def submit_form(xform_session, answers, prevalidated):
     else:
         resp = form_completion(xform_session)
         resp['status'] = 'success'
-
-    xml = xform_session.output()
-    # only try processing if user is on sql backend
-    if xform_session.uses_sql_backend:
-        process_form_xml(
-            xform_session.orig_params['api_auth'],
-            xml,
-            xform_session.orig_params['session_data']
-        )
+        
+        xml = xform_session.output()
+        # only try processing if user is on sql backend
+        if xform_session.uses_sql_backend:
+            process_form_xml(
+                xform_session.orig_params['api_auth'],
+                xml,
+                xform_session.orig_params['session_data']
+            )
 
     return xform_session.response(resp, no_next=True)
 


### PR DESCRIPTION
Fixes http://manage.dimagi.com/default.asp?241806

If a form had errors (IE missing required questions) and a case block, we would find the errors, then still process the XML to check its validity. If the form was invalid then the xforms-revalidate blocks would never trigger, so the timeEnd block wouldn't have been set. Then we would report to the user the "Case date last modified cannot be null" instead of reporting the root issue that there were missing questions. 