### PR TITLE
Conditionally log post_data_helper response

### DIFF
--- a/touchforms/formplayer/api.py
+++ b/touchforms/formplayer/api.py
@@ -277,7 +277,7 @@ class XformsResponse(object):
                                         "contact your administrator for help."})
 
 
-def post_data_helper(d, auth, content_type, url):
+def post_data_helper(d, auth, content_type, url, log=False):
     d['nav_mode'] = 'prompt'
     data = json.dumps(d)
     up = urlparse(url)
@@ -288,7 +288,11 @@ def post_data_helper(d, auth, content_type, url):
     conn = httplib.HTTPConnection(up.netloc)
     conn.request('POST', up.path, data, headers)
     resp = conn.getresponse()
+    if log:
+        logging.info("Response: %s" % resp)
     results = resp.read()
+    if log:
+        logging.info("Results: %s" % results)
     return results
             
 def post_data(data, auth=None, content_type="application/json"):
@@ -338,7 +342,7 @@ def perform_experiment(data, auth, content_type):
         c.record(post_data_helper(data, auth, content_type, settings.XFORMS_PLAYER_URL))
 
     with experiment.candidate() as c:
-        c.record(post_data_helper(candidate_data, auth, content_type, settings.FORMPLAYER_URL + "/" + data["action"]))
+        c.record(post_data_helper(candidate_data, auth, content_type, settings.FORMPLAYER_URL + "/" + data["action"], True))
 
     objects = experiment.run()
     return objects

--- a/touchforms/formplayer/api.py
+++ b/touchforms/formplayer/api.py
@@ -342,7 +342,8 @@ def perform_experiment(data, auth, content_type):
         c.record(post_data_helper(data, auth, content_type, settings.XFORMS_PLAYER_URL))
 
     with experiment.candidate() as c:
-        c.record(post_data_helper(candidate_data, auth, content_type, settings.FORMPLAYER_URL + "/" + data["action"], True))
+        c.record(post_data_helper(candidate_data, auth,
+                                  content_type, settings.FORMPLAYER_URL + "/" + data["action"], True))
 
     objects = experiment.run()
     return objects


### PR DESCRIPTION
@gcapalbo I'm still pretty stumped by what's going on here... the logs currently show:

```
Traceback (most recent call last):
  File "/home/cchq/www/production/current/python_env/local/lib/python2.7/site-packages/laboratory/experiment.py", line 46, in run
    self.publish(result)
  File "/home/cchq/www/production/current/submodules/touchforms-src/touchforms/formplayer/experiments.py", line 32, in publish
    candidate_dict = json.loads(candidate.value)
AttributeError: 'Observation' object has no attribute 'value'
```

Which looks like no experiment is ever run, so presumably we're error-ing out sometime while processing the request response. Formplayer logs show no trace of the requests which suggests to me something is going on with auth. Hoping that logging the responses immediately will illuminate this. Let me know if you have any thoughts