### PR TITLE
Log entire URL string

### DIFF
--- a/touchforms/formplayer/api.py
+++ b/touchforms/formplayer/api.py
@@ -283,7 +283,7 @@ def post_data_helper(d, auth, content_type, url, log=False):
     data = json.dumps(d)
     up = urlparse(url)
     if log:
-        logging.info("Request to url: %s%s" % (up.netloc, up.path))
+        logging.info("Request to url: %s" % up.geturl())
     headers = {}
     headers["content-type"] = content_type
     headers["content-length"] = len(data)


### PR DESCRIPTION
The logging I was doing before didn't have the `scheme` component (noob). the logs currently are showing a `301 moved` response for the requests to Formplayer, which I can reproduce when I have `http` or nothing as the scheme (instead of `https`). @gcapalbo do you think it could be the case that the wrong scheme is being used? Looks like `https` is the `DEFAULT_PROTOCOL` in `localsettings.py` on `hqcelery1` so that seems right