### PR TITLE
Don't send blank answers to formplayer

### DIFF
--- a/touchforms/formplayer/sms.py
+++ b/touchforms/formplayer/sms.py
@@ -28,7 +28,10 @@ def start_session(config):
     return SessionStartInfo(xformsresponse, config.domain)
 
 def next_responses(session_id, answer, domain, auth=None):
-    xformsresponse = answer_question(session_id, _tf_format(answer), domain, auth)
+    if answer:
+        xformsresponse = answer_question(session_id, _tf_format(answer), domain, auth)
+    else:
+        xformsresponse = next(session_id, domain, auth)
     for resp in _next_responses(xformsresponse, session_id, domain, auth):
         yield resp
 


### PR DESCRIPTION
Sending a blank answer to touchforms would cause it to skip to the next question. Formplayer raises an error though, so we have to explicitly skip to the next question. Tests pass with this change for both touchforms and formplayer.

@wpride @dannyroberts 