### PR TITLE
Start passing hmac digest on smsforms formplayer requests

### DIFF
--- a/touchforms/formplayer/api.py
+++ b/touchforms/formplayer/api.py
@@ -8,6 +8,7 @@ import copy
 from dimagi.utils.couch.cache.cache_core import get_redis_client
 
 from corehq.form_processor.utils.general import use_sqlite_backend
+from corehq.util.hmac_request import get_hmac_digest, convert_to_bytestring_if_unicode
 from touchforms.formplayer.exceptions import BadDataError
 from experiments import FormplayerExperiment
 from corehq import toggles
@@ -295,13 +296,17 @@ def post_data_helper(d, auth, content_type, url, log=False):
 
 
 def formplayer_post_data_helper(d, auth, content_type, url):
-    data = json.dumps(d)
+    data = json.dumps(d).encode('utf-8')
     up = urlparse(url)
     logging.info("Request to url: %s" % up.geturl())
     headers = {}
     headers["Content-Type"] = content_type
     headers["content-length"] = len(data)
     headers["Cookie"] = 'sessionid=%s' % settings.FORMPLAYER_INTERNAL_AUTH_KEY
+    headers["X-MAC-DIGEST"] = get_hmac_digest(
+        convert_to_bytestring_if_unicode(settings.FORMPLAYER_INTERNAL_AUTH_KEY),
+        data
+    )
     response = requests.post(
             url,
             data=data,

--- a/touchforms/formplayer/api.py
+++ b/touchforms/formplayer/api.py
@@ -301,6 +301,7 @@ def formplayer_post_data_helper(d, auth, content_type, url):
     headers = {}
     headers["Content-Type"] = content_type
     headers["content-length"] = len(data)
+    # Remove Cookie header once formplayer supports mac digest header for auth
     headers["Cookie"] = 'sessionid=%s' % settings.FORMPLAYER_INTERNAL_AUTH_KEY
     headers["X-MAC-DIGEST"] = get_hmac_digest(settings.FORMPLAYER_INTERNAL_AUTH_KEY, data)
     response = requests.post(

--- a/touchforms/formplayer/api.py
+++ b/touchforms/formplayer/api.py
@@ -307,9 +307,9 @@ def formplayer_post_data_helper(d, auth, content_type, url):
         data
     )
     response = requests.post(
-            url,
-            data=data,
-            headers=headers
+        url,
+        data=data,
+        headers=headers
     )
     response_json = response.json()
     return response.text

--- a/touchforms/formplayer/api.py
+++ b/touchforms/formplayer/api.py
@@ -298,7 +298,6 @@ def post_data_helper(d, auth, content_type, url, log=False):
 def formplayer_post_data_helper(d, auth, content_type, url):
     data = json.dumps(d).encode('utf-8')
     up = urlparse(url)
-    logging.info("Request to url: %s" % up.geturl())
     headers = {}
     headers["Content-Type"] = content_type
     headers["content-length"] = len(data)
@@ -313,8 +312,6 @@ def formplayer_post_data_helper(d, auth, content_type, url):
             headers=headers
     )
     response_json = response.json()
-    logging.info("Response: %s" % response)
-    logging.info("Results: %s" % response_json)
     return response.text
 
 

--- a/touchforms/formplayer/api.py
+++ b/touchforms/formplayer/api.py
@@ -302,10 +302,7 @@ def formplayer_post_data_helper(d, auth, content_type, url):
     headers["Content-Type"] = content_type
     headers["content-length"] = len(data)
     headers["Cookie"] = 'sessionid=%s' % settings.FORMPLAYER_INTERNAL_AUTH_KEY
-    headers["X-MAC-DIGEST"] = get_hmac_digest(
-        convert_to_bytestring_if_unicode(settings.FORMPLAYER_INTERNAL_AUTH_KEY),
-        data
-    )
+    headers["X-MAC-DIGEST"] = get_hmac_digest(settings.FORMPLAYER_INTERNAL_AUTH_KEY, data)
     response = requests.post(
         url,
         data=data,


### PR DESCRIPTION
We can release this without changes to formplayer. Once formplayer validates this header in its requests then we can get rid of the Cookie header it's passing now.

Depends on https://github.com/dimagi/commcare-hq/pull/20916

@snopoke @wpride 