### PR TITLE
Don't fake django sessionid anymore in formplayer requests

### DIFF
--- a/touchforms/formplayer/api.py
+++ b/touchforms/formplayer/api.py
@@ -301,8 +301,6 @@ def formplayer_post_data_helper(d, auth, content_type, url):
     headers = {}
     headers["Content-Type"] = content_type
     headers["content-length"] = len(data)
-    # Remove Cookie header once formplayer supports mac digest header for auth
-    headers["Cookie"] = 'sessionid=%s' % settings.FORMPLAYER_INTERNAL_AUTH_KEY
     headers["X-MAC-DIGEST"] = get_hmac_digest(settings.FORMPLAYER_INTERNAL_AUTH_KEY, data)
     response = requests.post(
         url,


### PR DESCRIPTION
@wpride @snopoke 

this isn't needed anymore and actually makes requests fail because formplayer now relies on the django session id to determine whether it makes requests with hmac headers or not

should go with https://github.com/dimagi/commcare-hq/pull/20953 and https://github.com/dimagi/formplayer/pull/661